### PR TITLE
Fix: Collect all media properties

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ const ReadHandler = async (req, next) => {
                 // TODO: How do we uniquely identify an asset?
                 const res = await media_srv.onGET(`${data[k].name}.png`)
                 const fileName = res[0].fileName ? res[0].fileName : res[0].Key
-                if (!data[k]?.[v]) data[k] = { [v]: {} };
+                if (!data[k]?.[v]) data[k] = Object.assign(data[k], { [v]: {} });
                 data[k][v].url = `/media/?file=${fileName}`
                 data[k][v]['url@odata.mediaReadLink'] = `/media/?file=${fileName}`
             }


### PR DESCRIPTION
- Fixes bug in collection of media properties
- Issue: Otherwise properties are left out, which would lead to, for example, missing names in the header title: 
     <img width="422" alt="Screenshot 2023-11-06 at 10 51 46" src="https://github.com/cap-js/attachments/assets/8320933/9cccc926-e1f3-4520-8efa-2b6331a755dc">

- With this fix, all properties are preserved:
      <img width="422" alt="Screenshot 2023-11-06 at 10 50 55" src="https://github.com/cap-js/attachments/assets/8320933/3033c5b0-43cf-4532-a4dc-7ebf1ea58cd4">
