### PR TITLE
Better names in model

### DIFF
--- a/index.cds
+++ b/index.cds
@@ -49,9 +49,6 @@ context sap.attachments {
   }
 
   annotate AttachmentsTable with @(UI: {
-    MediaResource: {
-      Stream: content
-    },
     PresentationVariant: {
       Visualizations: ['@UI.LineItem'],
       SortOrder     : [{


### PR DESCRIPTION
- Rename `AttachmentsView` => `AttachmentsTable` (it is an entity, not a view)
- Rename `entityKey` => `object` (to reflect the object we are attached to)