### PR TITLE
add delay before setting scan status to clean in local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 1.1.1
+
+### Changed
+
+- Enabled malware scanning in hybrid profile by default.
+- Added a 10 sec delay before setting scan status to `Clean` if malware scanning is default.
 
 ## Version 1.1.0
 

--- a/lib/malwareScanner.js
+++ b/lib/malwareScanner.js
@@ -17,15 +17,18 @@ async function scanRequest(Attachments, key) {
 
   let currEntity = draftEntity == undefined ? activeEntity : draftEntity
 
+  await updateStatus(AttachmentsSrv, key, "Scanning", currEntity, draftEntity, activeEntity)
+
   if (!scanEnabled) {
-    DEBUG?.('Malware scanning is disabled. Setting scan status to Clean.')
-    await updateStatus(AttachmentsSrv, key, "Clean", currEntity, draftEntity, activeEntity)
+    setTimeout(async () => {
+      DEBUG?.('Malware scanning is disabled. Setting scan status to Clean.')
+      await updateStatus(AttachmentsSrv, key, "Clean", currEntity, draftEntity, activeEntity)
+    }, 10000)
+
     return
   }
   
   const credentials = getCredentials()
-  await updateStatus(AttachmentsSrv, key, "Scanning", currEntity, draftEntity, activeEntity)
-
   const contentStream = await AttachmentsSrv.get(currEntity, key)
   let fileContent
   try {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
       },
       "[hybrid]": {
         "attachments": {
-          "kind": "s3"
+          "kind": "s3",
+          "scan": true
         }
       }
     }


### PR DESCRIPTION
- added a delay of 10 seconds before setting scan status as true if scan is disabled.
- set scan to true by default for hybrid profile.