### PR TITLE
Fix missing filename plugin when creating parent entity

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -32,7 +32,7 @@ cds.once("served", async function registerPluginHandlers() {
         for (let elementName in entity.elements) {
           if (elementName === "SiblingEntity") continue; // REVISIT: Why do we have this?
           const element = entity.elements[elementName], target = element._target;
-          if (target?.["@_is_media_data"]) {
+          if (target?.["@_is_media_data"] && target.drafts) {
             DEBUG?.("serving attachments for:", target.name);
             
             srv.after("READ", [target, target.drafts], readAttachment);

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -44,7 +44,7 @@ cds.once("served", async function registerPluginHandlers() {
             srv.before('NEW', target.drafts, req => {
               req.data.url = cds.utils.uuid();
               req.data.ID = cds.utils.uuid();
-              let ext = extname(req.data.filename || '').toLowerCase().slice(1);
+              let ext = extname(req.data.filename).toLowerCase().slice(1);
               req.data.mimeType = Ext2MimeTyes[ext] || "application/octet-stream";
             });
           }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -32,7 +32,7 @@ cds.once("served", async function registerPluginHandlers() {
         for (let elementName in entity.elements) {
           if (elementName === "SiblingEntity") continue; // REVISIT: Why do we have this?
           const element = entity.elements[elementName], target = element._target;
-          if (target?.["@_is_media_data"] && target.drafts) {
+          if (target?.["@_is_media_data"] && target?.drafts) {
             DEBUG?.("serving attachments for:", target.name);
             
             srv.after("READ", [target, target.drafts], readAttachment);

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -42,7 +42,7 @@ cds.once("served", async function registerPluginHandlers() {
             srv.before('NEW', target.drafts, req => {
               req.data.url = cds.utils.uuid();
               req.data.ID = cds.utils.uuid();
-              let ext = extname(req.data.filename).toLowerCase().slice(1);
+              let ext = extname(req.data.filename || '').toLowerCase().slice(1);
               req.data.mimeType = Ext2MimeTyes[ext] || "application/octet-stream";
             });
           }


### PR DESCRIPTION
No idea what exactly is going on, but the handler in our case is triggered when creating the parent of a parent of attachments tables, failing the whole handler.