### PR TITLE
fix(validate): req._path might be undefined

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -56,7 +56,7 @@ cds.once("served", async function registerPluginHandlers() {
   }
 
   async function validateAttachment(req) {
-    if(req._path.endsWith("content")) {
+    if(req._path?.endsWith("content")) {
       const status = await AttachmentsSrv.getStatus(req.target, req.params.at(-1));
       if(status !== 'Clean') {
         req.reject(403, 'Unable to download the attachment as scan status is not clean.');


### PR DESCRIPTION
Note: In general, you should not rely on `_path`.