### PR TITLE
profile based scan changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 
 - Updated Node version restriction.
+- Scan status is set to `clean` in development profile and to `unscanned` in hybrid/production profile, when malware scan is disabled.
+- When malware scan is disabled, uploaded attachment can be downloaded.
 
 ## Version 1.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 1.1.4
+
+### Changed
+
+- Updated Node version restriction.
+
 ## Version 1.1.3
 
 ### Changed

--- a/lib/malwareScanner.js
+++ b/lib/malwareScanner.js
@@ -17,16 +17,19 @@ async function scanRequest(Attachments, key) {
 
   let currEntity = draftEntity == undefined ? activeEntity : draftEntity
 
-  await updateStatus(AttachmentsSrv, key, "Scanning", currEntity, draftEntity, activeEntity)
-
   if (!scanEnabled) {
-    setTimeout(async () => {
-      DEBUG?.('Malware scanning is disabled. Setting scan status to Clean.')
-      await updateStatus(AttachmentsSrv, key, "Clean", currEntity, draftEntity, activeEntity)
-    }, 5000)
-
-    return
+    if (cds.env.profiles.length === 1 && cds.env.profiles[0] === "development") {
+      setTimeout(async () => {
+        DEBUG?.('Malware scanning is disabled. Setting scan status to Clean in development profile.')
+        await updateStatus(AttachmentsSrv, key, "Clean", currEntity, draftEntity, activeEntity)
+      }, 5000)
+      return
+    } else {
+      return
+    }
   }
+
+  await updateStatus(AttachmentsSrv, key, "Scanning", currEntity, draftEntity, activeEntity)
   
   const credentials = getCredentials()
   const contentStream = await AttachmentsSrv.get(currEntity, key)

--- a/lib/malwareScanner.js
+++ b/lib/malwareScanner.js
@@ -19,6 +19,7 @@ async function scanRequest(Attachments, key) {
 
   if (!scanEnabled) {
     if (cds.env.profiles.length === 1 && cds.env.profiles[0] === "development") {
+      await updateStatus(AttachmentsSrv, key, "Scanning", currEntity, draftEntity, activeEntity)
       setTimeout(async () => {
         DEBUG?.('Malware scanning is disabled. Setting scan status to Clean in development profile.')
         await updateStatus(AttachmentsSrv, key, "Clean", currEntity, draftEntity, activeEntity)

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -58,7 +58,8 @@ cds.once("served", async function registerPluginHandlers() {
   async function validateAttachment(req) {
     if(req._path?.endsWith("content")) {
       const status = await AttachmentsSrv.getStatus(req.target, req.params.at(-1));
-      if(status !== 'Clean') {
+      const scanEnabled = cds.env.requires?.attachments?.scan ?? true
+      if(scanEnabled && status !== 'Clean') {
         req.reject(403, 'Unable to download the attachment as scan status is not clean.');
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cap-js/attachments",
   "description": "CAP cds-plugin providing image and attachment storing out-of-the-box.",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "repository": "cap-js/attachments",
   "author": "SAP SE (https://www.sap.com)",
   "homepage": "https://cap.cloud.sap/",

--- a/xmpl/db/init.js
+++ b/xmpl/db/init.js
@@ -9,7 +9,7 @@ module.exports = async function () {
   await attachments.put (Attachments, [
     [ '3b23bb4b-4ac7-4a24-ac02-aa10cabd842c', 'INVERTER FAULT REPORT.pdf', 'application/pdf', cds.utils.uuid(),cds.utils.uuid(), 'Unscanned'],
     [ '3b23bb4b-4ac7-4a24-ac02-aa10cabd842c', 'Inverter-error-logs.txt', 'application/txt' , cds.utils.uuid(), cds.utils.uuid(),'Clean'],
-    [ '3a4ede72-244a-4f5f-8efa-b17e032d01ee', 'No_Current.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', cds.utils.uuid(), cds.utils.uuid(),'Under Scan'],
+    [ '3a4ede72-244a-4f5f-8efa-b17e032d01ee', 'No_Current.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', cds.utils.uuid(), cds.utils.uuid(),'Scanning'],
     [ '3ccf474c-3881-44b7-99fb-59a2a4668418', 'strange-noise.csv', 'text/csv', cds.utils.uuid(), cds.utils.uuid(),'Malware Detected'],
     [ '3583f982-d7df-4aad-ab26-301d4a157cd7', 'Broken Solar Panel.jpg', 'image/jpeg', cds.utils.uuid(), cds.utils.uuid(),'Clean'],
   ].map(([ up__ID, filename, mimeType, url, ID , status]) => ({


### PR DESCRIPTION
- When `"scan": false`:

- [x] Scan status is set to `clean` in development profile 
- [x] Scan status is set to `unscanned` in hybrid/production profile
- [x] User can download the uploaded attachment