### PR TITLE
Adaption to cds 8

### DIFF
--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -97,7 +97,7 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
 }
 
   async updateContentHandler(req, next) {
-    if (req._path.endsWith("content")) {
+    if (req?.data?.content) {
       const response = await SELECT.from(req.target, { ID: req.data.ID }).columns("url");
       if (response?.url) {
         const Key = response.url;

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -66,7 +66,7 @@ cds.once("served", async function registerPluginHandlers() {
   }
 
   async function readAttachment([attachment], req) {
-    if (!req._path?.endsWith("content") || !attachment || attachment?.content) return;
+    if (!req.data?.content || !attachment || attachment?.content) return;
     let keys = req.params.at(-1);
     let { target } = req;
     attachment.content = await AttachmentsSrv.get(target, keys, req); //Dependency -> sending req object for usage in SDM plugin

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,6 +2,7 @@ const cds = require("@sap/cds/lib");
 const LOG = cds.log("attachments");
 const { extname } = require("path");
 const DEBUG = LOG._debug ? LOG.debug : undefined;
+const attachmentIDRegex = /attachments\(.*ID=([^,]+),.*\)/;
 
 cds.on("loaded", function unfoldModel(csn) {
   if (!("Attachments" in csn.definitions)) return;
@@ -56,8 +57,19 @@ cds.once("served", async function registerPluginHandlers() {
   }
 
   async function validateAttachment(req) {
-    if(req._path?.endsWith("content")) {
-      const status = await AttachmentsSrv.getStatus(req.target, req.params.at(-1));
+    
+    /* removing case condition for mediaType annotation as in our case binary value and metadata is stored in different database */
+    
+    req?.query?.SELECT?.columns?.forEach((el) => {
+      if(el.as === 'content@odata.mediaContentType' && el.xpr){
+        delete el.xpr;
+        el.ref = ['mimeType'];
+      }
+    });
+
+    if(req?.req?.url?.endsWith("content")) {
+      const attachmentID = req.req.url.match(attachmentIDRegex)[1];
+      const status = await AttachmentsSrv.getStatus(req.target, { ID : attachmentID });
       const scanEnabled = cds.env.requires?.attachments?.scan ?? true
       if(scanEnabled && status !== 'Clean') {
         req.reject(403, 'Unable to download the attachment as scan status is not clean.');
@@ -66,8 +78,8 @@ cds.once("served", async function registerPluginHandlers() {
   }
 
   async function readAttachment([attachment], req) {
-    if (!req.data?.content || !attachment || attachment?.content) return;
-    let keys = req.params.at(-1);
+    if (!req?.req?.url?.endsWith("content") || !attachment || attachment?.content) return;
+    let keys = { ID : req.req.url.match(attachmentIDRegex)[1]};
     let { target } = req;
     attachment.content = await AttachmentsSrv.get(target, keys, req); //Dependency -> sending req object for usage in SDM plugin
   }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -60,14 +60,14 @@ cds.once("served", async function registerPluginHandlers() {
     
     /* removing case condition for mediaType annotation as in our case binary value and metadata is stored in different database */
     
-    req?.query?.SELECT?.columns?.forEach((el) => {
-      if(el.as === 'content@odata.mediaContentType' && el.xpr){
-        delete el.xpr;
-        el.ref = ['mimeType'];
+    req?.query?.SELECT?.columns?.forEach((element) => {
+      if(element.as === 'content@odata.mediaContentType' && element.xpr){
+        delete element.xpr;
+        element.ref = ['mimeType'];
       }
     });
 
-    if(req?.req?.url?.endsWith("content")) {
+    if(req?.req?.url?.endsWith("/content")) {
       const attachmentID = req.req.url.match(attachmentIDRegex)[1];
       const status = await AttachmentsSrv.getStatus(req.target, { ID : attachmentID });
       const scanEnabled = cds.env.requires?.attachments?.scan ?? true
@@ -78,7 +78,7 @@ cds.once("served", async function registerPluginHandlers() {
   }
 
   async function readAttachment([attachment], req) {
-    if (!req?.req?.url?.endsWith("content") || !attachment || attachment?.content) return;
+    if (!req?.req?.url?.endsWith("/content") || !attachment || attachment?.content) return;
     let keys = { ID : req.req.url.match(attachmentIDRegex)[1]};
     let { target } = req;
     attachment.content = await AttachmentsSrv.get(target, keys, req); //Dependency -> sending req object for usage in SDM plugin

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jest": "^29.7.0"
   },
   "peerDependencies": {
-    "@sap/cds": "7.8.0"
+    "@sap/cds": "8.0.0"
   },
   "engines": {
     "node": ">=17.0.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jest": "^29.7.0"
   },
   "peerDependencies": {
-    "@sap/cds": "8.0.0"
+    "@sap/cds": ">=8"
   },
   "engines": {
     "node": ">=17.0.0"


### PR DESCRIPTION
1. Removing case for `content@odata.mediaContentType` value
2. Updating checks as per the latest request object
3. Added regex to get the attachment ID (previously was able to access params directly)