### PR TITLE
Bug fix: Composition from an aspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 1.1.7
+
+### Fixed
+
+- Fix for scenario where an aspect has a composition.
+
 ## Version 1.1.6
 
 ### Added

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -8,7 +8,7 @@ cds.on("loaded", function unfoldModel(csn) {
   if (!("Attachments" in csn.definitions)) return;
   const csnCopy = structuredClone(csn)
   cds.linked(csnCopy).forall("Composition", (comp) => {
-    if (comp._target["@_is_media_data"] && comp.parent && comp.is2many) {
+    if (comp._target && comp._target["@_is_media_data"] && comp.parent && comp.is2many) {
       const parentDefinition = comp.parent.name
       let facets = csn.definitions[parentDefinition]["@UI.Facets"];
       if (!facets) return;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cap-js/attachments",
   "description": "CAP cds-plugin providing image and attachment storing out-of-the-box.",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "repository": "cap-js/attachments",
   "author": "SAP SE (https://www.sap.com)",
   "homepage": "https://cap.cloud.sap/",


### PR DESCRIPTION
In case of an aspect having a check to another aspect (irrespective of it being an `attachment` or not), our plugin throws an error. 
Our plugin throws an error because -> the composition doesn't have a `_target` , instead it has a `targetAspect`.
In our plugin we only handle Composition from entities, hence, have added a check that Composition._target should exist, then only have further checks for attachments

Issue link : https://github.com/cap-js/attachments/issues/100