### PR TITLE
fix: remove @Core.Immutable

### DIFF
--- a/index.cds
+++ b/index.cds
@@ -42,5 +42,4 @@ annotate Attachments with @UI:{
 } {
   content
     @Core.ContentDisposition: { Filename: filename, Type: 'inline' }
-    @Core.Immutable
 }


### PR DESCRIPTION
It must be allowed to update `content`, specially since the wrapper row must be created beforehand, according to OData.