### PR TITLE
fix ordering of default value and annotation

### DIFF
--- a/index.cds
+++ b/index.cds
@@ -4,7 +4,7 @@ namespace sap.attachments;
 aspect MediaData @(_is_media_data) {
   url      : String;
   content  : LargeBinary @title: 'Attachment'; // only for db-based services
-  mimeType : String @title: 'Media Type' default 'application/octet-stream';
+  mimeType : String default 'application/octet-stream' @title: 'Media Type';
   filename : String @title: 'Filename';
   status   :  String @title: 'Scan Status' enum {
     Unscanned;


### PR DESCRIPTION
Compiling any CAP project, which uses @cap-js/attachments, with the latest version, the following warning is displayed for the cds compile command:

```sh
npx -p @sap/cds-dk cds compile index.cds -o index.cds.json
[WARNING] index.cds:7:42-49: Unexpected ‘default’ after annotation assignment
```

This commit addresses this warning by reordering the `default` value and the `title` annotation. 