### PR TITLE
Fix dangling timers causing tests to fail. 

### DIFF
--- a/lib/malwareScanner.js
+++ b/lib/malwareScanner.js
@@ -22,7 +22,7 @@ async function scanRequest(Attachments, key) {
       setTimeout(async () => {
         DEBUG?.('Malware scanning is disabled. Setting scan status to Clean in development profile.')
         await updateStatus(AttachmentsSrv, key, "Clean", currEntity, draftEntity, activeEntity)
-      }, 5000)
+      }, 5000).unref()
       return
     } else {
       return


### PR DESCRIPTION
Always add `.unref()` to all timers created to avoid falling tests.

For example, in this case, the tests hang until the timeout appears after the server has been shutdown, and hence the database been purged: 

```js
[cds] - ❗️Uncaught SqliteError: no such table: sap_capire_incidents_Incidents_attachments in:
UPDATE sap_capire_incidents_Incidents_attachments AS attachments SET status=?,modifiedAt=session_context('$now'),modifiedBy=session_context('$user.id') WHERE attachments.ID = ?
    at Database.prepare (/cap/dev/node_modules/better-sqlite3/lib/methods/wrappers.js:5:21)
    at SQLiteService.prepare (/cap/dev/cds-dbs/sqlite/lib/SQLiteService.js:72:29)
    at SQLiteService.onSIMPLE (/cap/dev/cds-dbs/sqlite/lib/SQLiteService.js:143:25)
    at SQLiteService.onUPDATE (/cap/dev/cds-dbs/db-service/lib/SQLService.js:202:17)
    at SQLiteService.onUPDATE (/cap/dev/cds-dbs/sqlite/lib/SQLiteService.js:278:26)
    at next (/cap/dev/cds/lib/srv/srv-dispatch.js:64:36)
    at SQLiteService.onDeep (/cap/dev/cds-dbs/db-service/lib/deep-queries.js:43:39)
    at next (/cap/dev/cds/lib/srv/srv-dispatch.js:64:36)
    at SQLiteService.fill_in_keys (/cap/dev/cds-dbs/db-service/lib/fill-in-keys.js:74:10)
    at next (/cap/dev/cds/lib/srv/srv-dispatch.js:64:36) {
  code: 'SQLITE_ERROR',
  query: "UPDATE sap_capire_incidents_Incidents_attachments AS attachments SET status=?,modifiedAt=session_context('$now'),modifiedBy=session_context('$user.id') WHERE attachments.ID = ?",
  values: { status: 'Clean' }
}
```