### PR TITLE
Fixed check on 404 to be robust

### DIFF
--- a/tests/integration/attachments.test.js
+++ b/tests/integration/attachments.test.js
@@ -154,13 +154,9 @@ describe("Tests for uploading/deleting attachments through API calls - in-memory
     }
 
     //content should not be there
-    try {
-      await GET(
-        `odata/v4/processor/Incidents(ID=${incidentID},IsActiveEntity=true)/attachments(up__ID=${incidentID},ID=${sampleDocID},IsActiveEntity=true)/content`
-      );
-    } catch (err) {
-      expect(err.code).to.equal("ERR_BAD_REQUEST");
-    }
+    await expect(GET(
+      `odata/v4/processor/Incidents(ID=${incidentID},IsActiveEntity=true)/attachments(up__ID=${incidentID},ID=${sampleDocID},IsActiveEntity=true)/content`
+    )).to.be.rejectedWith(/404/);
   });
 });
 


### PR DESCRIPTION
More robust as it checks what we really can expect. 
Also works with [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API), which we will use in future, the other only worked with Axios.
