### PR TITLE
Fix: Improve error handling for malware scanning mock

### DIFF
--- a/lib/malwareScanner.js
+++ b/lib/malwareScanner.js
@@ -19,9 +19,10 @@ async function scanRequest(Attachments, key) {
   if (!scanEnabled) {
     if (cds.env.profiles.some(p => p === "development" || p === "test") && !cds.env.profiles.includes("hybrid")) {
       await updateStatus(AttachmentsSrv, key, "Scanning", currEntity, draftEntity, activeEntity)
-      setTimeout(async () => {
+      setTimeout(() => {
         DEBUG?.('Malware scanning is disabled. Setting scan status to Clean in development profile.')
-        await updateStatus(AttachmentsSrv, key, "Clean", currEntity, draftEntity, activeEntity)
+        updateStatus(AttachmentsSrv, key, "Clean", currEntity, draftEntity, activeEntity)
+        .catch(e => cds.log('attachments').error(e))
       }, 5000).unref()
       return
     } else {


### PR DESCRIPTION
This avoids strange errors happening in our internal test pipelines whenever one of the attachments tests are involved. 