### PR TITLE
Fixsupport 'standard' and fallback 's3-standard' plans for object store …

### DIFF
--- a/lib/mtx/server.js
+++ b/lib/mtx/server.js
@@ -45,7 +45,7 @@ const _serviceManagerRequest = async (sm_url, method, path, token, params = {}) 
             params
         });
 
-        return response.data.items[0];
+        return response?.data?.items?.[0]; // Error handling : return undefined instead of crashing when .items is undefined
 
     } catch (error) {
         DEBUG?.(`Error fetching data from service manager: ${error.message}`);
@@ -80,11 +80,33 @@ const _getOfferingID = async (sm_url, token) => {
 }
 
 const _getPlanID = async (sm_url, token, offeringID) => {
-    // Recheck the fieldQuery for catalog_name
-    const plans = await _serviceManagerRequest(sm_url, HTTP_METHOD.GET, PATH.SERVICE_PLAN, token, { fieldQuery: `service_offering_id eq '${offeringID}' and catalog_name eq 's3-standard'` });
-    const planID = plans.id;
-    if (!planID) DEBUG?.('Object store service plan not found');
-    return planID;
+  // Recheck the fieldQuery for catalog_name
+  const supportedPlans = ["standard", "s3-standard"];
+  for (const planName of supportedPlans) {
+    try {
+      const plan = await _serviceManagerRequest(
+        sm_url,
+        HTTP_METHOD.GET,
+        PATH.SERVICE_PLAN,
+        token,
+        {
+          fieldQuery: `service_offering_id eq '${offeringID}' and catalog_name eq '${planName}'`,
+        }
+      );
+      if (plan?.id) {
+        DEBUG?.(`Using object store plan "${planName}" with ID: ${plan.id}`);
+        return plan.id;
+      }
+    } catch (error) {
+      DEBUG?.(`Failed to fetch plan "${planName}": ${error.message}`);
+    }
+  }
+  DEBUG?.(
+    `No valid object store plan found (attempted: ${supportedPlans.join(", ")})`
+  );
+  throw new Error(
+    `No supported object store service plan found in Service Manager.`
+  );
 };
 
 const _createObjectStoreInstance = async (sm_url, tenant, planID, token) => {


### PR DESCRIPTION
…provisioning

Replaced hardcoded plan filter with flexible `supportedPlans` array
- Tries all supported plans in order and logs selected plan
- Fails gracefully with clear error if no matching plan is found