### PR TITLE
Update CI Node.js Versions to 20.x and 22.x for @sap/cds Compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 18.x]
+        node-version: [20.x, 22.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
### What Changed
- Removed Node.js 18.x from the GitHub Actions test matrix as it is no longer compatible with @sap/cds (requires Node.js >= 20).
- Updated Node.js versions in the matrix to test against 20.x and the latest available 22.x.

