### PR TITLE
Support attachments with custom primary key fields (non-ID keys)

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -118,7 +118,7 @@ cds.once("served", async function registerPluginHandlers () {
       }
     } catch (err) {
       LOG.error('[NON_DRAFT_UPLOAD_ERROR]', err);
-      req.reject(500, 'Non-draft attachment upload failed.');
+      throw Object.assign(new Error('Non-draft attachment upload failed.'), { statusCode: 500 });
     }
   }
 })


### PR DESCRIPTION
This PR introduces support in the @cap-js/attachments plugin to work with custom key names (not just ID) for entities using the attachments composition. It enables both draft and non-draft flows to work correctly when the key field is named differently (e.g., bookId, customId, etc.).

Fixes [#209](https://github.com/cap-js/attachments/issues/209)