### PR TITLE
Fix: Malware Scanning Refactor and Trigger Fix

### DIFF
--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -196,9 +196,17 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
         await Promise.all([multipartUpload.done()]);
 
         const keys = { ID: req.data.ID }
-        cds.spawn({
+        const scanRequest =cds.spawn({
           tenant: req.tenant
         }, async () => await scanRequest(req.target, keys, req));
+
+        scanRequest.on("succeeded", async () => {
+          DEBUG?.(`[S3 Upload & Scan] Scan Succeeded`);
+        });
+
+        scanRequest.on("failed", async (error) => {
+          DEBUG?.(`[S3 Upload & Scan] Scan Failed due to error - ${error}`);
+        });
         DEBUG?.(`[S3 Upload] Uploaded file using updateContentHandler for ${req.target.name}`);
       }
     } else if (req?.data?.note) {

--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -192,7 +192,7 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
         await Promise.all([multipartUpload.done()]);
 
         const keys = { ID: req.data.ID }
-        scanRequest(req.target, keys, req)
+        await scanRequest(req.target, keys, req)
         DEBUG?.(`[S3 Upload] Uploaded file using updateContentHandler for ${req.target.name}`);
       }
     } else if (req?.data?.note) {

--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -192,8 +192,11 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
         await Promise.all([multipartUpload.done()]);
 
         const keys = { ID: req.data.ID }
-        scanRequest(req.target, keys, req)
+        cds.spawn({
+          tenant: req.tenant
+        }, async () => await scanRequest(req.target, keys, req));
         DEBUG?.(`[S3 Upload] Uploaded file using updateContentHandler for ${req.target.name}`);
+        next();
       }
     } else if (req?.data?.note) {
       const key = { ID: req.data.ID };

--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -105,7 +105,11 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
       
       const stored = super.put(attachments, metadata, null, isDraftEnabled);
       await Promise.all([stored, multipartUpload.done()]);
-      if (this.kind === 's3') scanRequest(attachments, { ID: metadata.ID }, req);
+      if (this.kind === 's3') { 
+        cds.spawn({
+          tenant: req.tenant
+        }, scanRequest(req.target, { ID: metadata.ID }, req));
+      }
       DEBUG?.(`[S3 Upload] File uploaded successfully using put to ${this.bucket}`);
     } catch (err) {
       console.error(err); // eslint-disable-line no-console
@@ -194,7 +198,7 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
         const keys = { ID: req.data.ID }
         cds.spawn({
           tenant: req.tenant
-        }, async () => await scanRequest(req.target, keys, req));
+        }, scanRequest(req.target, keys, req));
         DEBUG?.(`[S3 Upload] Uploaded file using updateContentHandler for ${req.target.name}`);
       }
     } else if (req?.data?.note) {

--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -196,7 +196,6 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
           tenant: req.tenant
         }, async () => await scanRequest(req.target, keys, req));
         DEBUG?.(`[S3 Upload] Uploaded file using updateContentHandler for ${req.target.name}`);
-        next();
       }
     } else if (req?.data?.note) {
       const key = { ID: req.data.ID };

--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -105,7 +105,7 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
       
       const stored = super.put(attachments, metadata, null, isDraftEnabled);
       await Promise.all([stored, multipartUpload.done()]);
-      if (this.kind === 's3') scanRequest(attachments, { ID: metadata.ID }, req);
+      if (this.kind === 's3') await scanRequest(attachments, { ID: metadata.ID }, req);
       DEBUG?.(`[S3 Upload] File uploaded successfully using put to ${this.bucket}`);
     } catch (err) {
       console.error(err); // eslint-disable-line no-console
@@ -205,15 +205,16 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
   }
 
   async getAttachmentsToDelete({ draftEntity, activeEntity, id }) {
-    const [draftAttachments, activeAttachments] = await Promise.all([
-      SELECT.from(draftEntity).columns("url").where(id),
-      SELECT.from(activeEntity).columns("url").where(id)
-    ]);
+    const attachmentsStored = [];
+    draftEntity ? attachmentsStored.push(SELECT.from(draftEntity).where(id).columns('url')) : null;
+    activeEntity ? attachmentsStored.push(SELECT.from(activeEntity).where(id).columns('url')) : null;
+
+    const [draftAttachments, activeAttachments] = await Promise.all(attachmentsStored);
 
     const activeUrls = new Set(activeAttachments.map(a => a.url));
-    return draftAttachments
+
+    return attachmentsToDelete = draftAttachments
       .filter(({ url }) => !activeUrls.has(url))
-      .map(({ url }) => ({ url }));
   }
 
   async attachDraftDeletionData(req) {

--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -108,7 +108,7 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
       if (this.kind === 's3') { 
         cds.spawn({
           tenant: req.tenant
-        }, scanRequest(req.target, { ID: metadata.ID }, req));
+        }, async () => await scanRequest(req.target, keys, req));
       }
       DEBUG?.(`[S3 Upload] File uploaded successfully using put to ${this.bucket}`);
     } catch (err) {
@@ -198,16 +198,15 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
         const keys = { ID: req.data.ID }
         cds.spawn({
           tenant: req.tenant
-        }, scanRequest(req.target, keys, req));
+        }, async () => await scanRequest(req.target, keys, req));
         DEBUG?.(`[S3 Upload] Uploaded file using updateContentHandler for ${req.target.name}`);
       }
     } else if (req?.data?.note) {
       const key = { ID: req.data.ID };
       await super.update(req.target, key, { note: req.data.note });
       DEBUG?.(`[S3 Upload] Updated file upload with note for ${req.target.name}`);
-    } else {
-      next();
     }
+    next();
   }
 
   async getAttachmentsToDelete({ draftEntity, activeEntity, id }) {

--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -196,17 +196,11 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
         await Promise.all([multipartUpload.done()]);
 
         const keys = { ID: req.data.ID }
-        const scanRequest =cds.spawn({
+        
+        cds.spawn({
           tenant: req.tenant
         }, async () => await scanRequest(req.target, keys, req));
 
-        scanRequest.on("succeeded", async () => {
-          DEBUG?.(`[S3 Upload & Scan] Scan Succeeded`);
-        });
-
-        scanRequest.on("failed", async (error) => {
-          DEBUG?.(`[S3 Upload & Scan] Scan Failed due to error - ${error}`);
-        });
         DEBUG?.(`[S3 Upload] Uploaded file using updateContentHandler for ${req.target.name}`);
       }
     } else if (req?.data?.note) {

--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -192,7 +192,7 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
         await Promise.all([multipartUpload.done()]);
 
         const keys = { ID: req.data.ID }
-        await scanRequest(req.target, keys, req)
+        scanRequest(req.target, keys, req)
         DEBUG?.(`[S3 Upload] Uploaded file using updateContentHandler for ${req.target.name}`);
       }
     } else if (req?.data?.note) {

--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -114,7 +114,7 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
 
   // eslint-disable-next-line no-unused-vars
   async get(attachments, keys, req = {}) {
-    DEBUG?.(`[S3 Upload] Executing get for file in ${req.target.name}`);
+    DEBUG?.(`[S3 Upload] Executing get for file`);
     // Check separate object store instances
     if (separateObjectStore) {
       const tenantID = req.tenant;

--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -105,7 +105,7 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
       
       const stored = super.put(attachments, metadata, null, isDraftEnabled);
       await Promise.all([stored, multipartUpload.done()]);
-      if (this.kind === 's3') await scanRequest(attachments, { ID: metadata.ID }, req);
+      if (this.kind === 's3') scanRequest(attachments, { ID: metadata.ID }, req);
       DEBUG?.(`[S3 Upload] File uploaded successfully using put to ${this.bucket}`);
     } catch (err) {
       console.error(err); // eslint-disable-line no-console
@@ -192,7 +192,7 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
         await Promise.all([multipartUpload.done()]);
 
         const keys = { ID: req.data.ID }
-        await scanRequest(req.target, keys, req)
+        scanRequest(req.target, keys, req)
         DEBUG?.(`[S3 Upload] Uploaded file using updateContentHandler for ${req.target.name}`);
       }
     } else if (req?.data?.note) {

--- a/lib/malwareScanner.js
+++ b/lib/malwareScanner.js
@@ -109,11 +109,16 @@ function getCredentials() {
 
 function streamToString(stream) {
   const chunks = [];
-  return new Promise((resolve, reject) => {
-    stream.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
-    stream.on('error', (err) => reject(err))
-    stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
-  })
+  try {
+    return new Promise((resolve, reject) => {
+      stream.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+      stream.on('error', (err) => reject(err))
+      stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+    });
+  } catch (error) {
+    throw new Error("[Scan] Error in streaming data from content", error)
+  }
+
 }
 
 module.exports = {

--- a/lib/malwareScanner.js
+++ b/lib/malwareScanner.js
@@ -26,7 +26,7 @@ async function scanRequest(Attachments, key, req) {
   if (!scanEnabled) {
     await localMockedScan(key, req, currEntity, draftEntity, activeEntity);
   } else {
-    await remoteScan(key, req, currEntity, draftEntity, activeEntity);
+    remoteScan(key, req, currEntity, draftEntity, activeEntity);
   }
 }
 

--- a/lib/malwareScanner.js
+++ b/lib/malwareScanner.js
@@ -87,6 +87,7 @@ async function sendFileToMalwareScanner(fileContent) {
 }
 
 async function updateStatus(AttachmentsSrv, key, status, currEntity, draftEntity, activeEntity) {
+   DEBUG?.(`[Scan] Updating status for ${currEntity} - ${status}`);
   if (currEntity == draftEntity) {
     currEntity = await getCurrentEntity(currEntity, activeEntity, key)
   }

--- a/lib/malwareScanner.js
+++ b/lib/malwareScanner.js
@@ -56,7 +56,6 @@ async function remoteScan(key, req, currEntity, draftEntity, activeEntity) {
   } catch (err) {
     DEBUG?.("[Scan] Failed to execute Malware scan - ", err)
     await updateStatus(AttachmentsSrv, key, STATUS_FAILED, currEntity, draftEntity, activeEntity);
-    await updateStatus(AttachmentsSrv, key, STATUS_SCANNING, currEntity, draftEntity, activeEntity);
   }
 }
 
@@ -98,8 +97,9 @@ async function updateStatus(AttachmentsSrv, key, status, currEntity, draftEntity
   if (currEntity == draftEntity) {
     currEntity = await getCurrentEntity(currEntity, activeEntity, key)
   }
-  await AttachmentsSrv.update(currEntity, key, { status: status })
-  DEBUG?.(`[Scan] Updated status for ${currEntity} - ${status}`);
+  const entityName = typeof currEntity === 'string' ? currEntity : currEntity.name;
+  await AttachmentsSrv.update(entityName, key, { status: status })
+  DEBUG?.(`[Scan] Updated status for ${entityName} - ${status}`);
 }
 
 async function getCurrentEntity(draftEntity, activeEntity, key) {

--- a/lib/malwareScanner.js
+++ b/lib/malwareScanner.js
@@ -11,7 +11,6 @@ const STATUS_FAILED = "Failed";
 async function scanRequest(Attachments, key, req) {
   DEBUG?.(`[Scan] Scanning file uploaded for ${Attachments}`);
   const scanEnabled = cds.env.requires?.attachments?.scan ?? true
-  const AttachmentsSrv = await cds.connect.to("attachments")
 
   let draftEntity, activeEntity
   if (Attachments.isDraft) {
@@ -25,14 +24,16 @@ async function scanRequest(Attachments, key, req) {
   DEBUG?.(`[Scan] activeEntity = ${activeEntity}`);
 
   if (!scanEnabled) {
-    await localMockedScan(AttachmentsSrv, key, req, currEntity, draftEntity, activeEntity);
+    await localMockedScan(key, req, currEntity, draftEntity, activeEntity);
   } else {
-    await remoteScan(AttachmentsSrv, key, req, currEntity, draftEntity, activeEntity);
+    await remoteScan(key, req, currEntity, draftEntity, activeEntity);
   }
 }
 
-async function remoteScan(AttachmentsSrv, key, req, currEntity, draftEntity, activeEntity) {
+async function remoteScan(key, req, currEntity, draftEntity, activeEntity) {
   try {
+    const AttachmentsSrv = await cds.connect.to("attachments");
+
     DEBUG?.(`[Scan] Executing remote scan for ${currEntity.name}`);
     await updateStatus(AttachmentsSrv, key, STATUS_SCANNING, currEntity, draftEntity, activeEntity);
 
@@ -57,7 +58,9 @@ async function remoteScan(AttachmentsSrv, key, req, currEntity, draftEntity, act
   }
 }
 
-async function localMockedScan(AttachmentsSrv, key, req, currEntity, draftEntity, activeEntity) {
+async function localMockedScan(key, req, currEntity, draftEntity, activeEntity) {
+  const AttachmentsSrv = await cds.connect.to("attachments");
+
   DEBUG?.(`[Scan] Executing local mocked scan for ${currEntity.name}`);
   if (cds.env.profiles.some(p => p === "development" || p === "test") && !cds.env.profiles.includes("hybrid")) {
     await updateStatus(AttachmentsSrv, key, "Scanning", currEntity, draftEntity, activeEntity)

--- a/lib/malwareScanner.js
+++ b/lib/malwareScanner.js
@@ -56,6 +56,7 @@ async function remoteScan(key, req, currEntity, draftEntity, activeEntity) {
   } catch (err) {
     DEBUG?.("[Scan] Failed to execute Malware scan - ", err)
     await updateStatus(AttachmentsSrv, key, STATUS_FAILED, currEntity, draftEntity, activeEntity);
+    await updateStatus(AttachmentsSrv, key, STATUS_SCANNING, currEntity, draftEntity, activeEntity);
   }
 }
 
@@ -92,7 +93,7 @@ async function sendFileToMalwareScanner(fileContent) {
 
 async function updateStatus(AttachmentsSrv, key, status, currEntity, draftEntity, activeEntity) {
   DEBUG?.(`[Scan] Updating status for ${currEntity} - ${status}`);
-  DEBUG?.(`[Scan] Updating status - AttachmentsSrv: ${AttachmentsSrv} | key: ${JSON.stringify(key)} | currEntity: ${currEntity} | draftEntity: ${draftEntity} | activeEntity: ${activeEntity}`);
+  DEBUG?.(`[Scan] Updating status - AttachmentsSrv: ${JSON.stringify(AttachmentsSrv)} | key: ${JSON.stringify(key)} | currEntity: ${currEntity} | draftEntity: ${draftEntity} | activeEntity: ${activeEntity}`);
   
   if (currEntity == draftEntity) {
     currEntity = await getCurrentEntity(currEntity, activeEntity, key)

--- a/lib/malwareScanner.js
+++ b/lib/malwareScanner.js
@@ -36,7 +36,7 @@ async function remoteScan(AttachmentsSrv, key, req, currEntity, draftEntity, act
     DEBUG?.(`[Scan] Executing remote scan for ${currEntity.name}`);
     await updateStatus(AttachmentsSrv, key, STATUS_SCANNING, currEntity, draftEntity, activeEntity);
 
-    const contentStream = await AttachmentsSrv.get(currEntity, key);
+    const contentStream = await AttachmentsSrv.get(currEntity, key, req.tenant);
     const fileContent = await streamToString(contentStream);
 
     const malwareScannerResponse = await sendFileToMalwareScanner(fileContent);
@@ -52,7 +52,7 @@ async function remoteScan(AttachmentsSrv, key, req, currEntity, draftEntity, act
     DEBUG?.(`[Scan] Scanned file with status: ${status}`, key);
     await updateStatus(AttachmentsSrv, key, status, currEntity, draftEntity, activeEntity);
   } catch (err) {
-    DEBUG?.("[Scan] Failed to execute Malware scan", err)
+    DEBUG?.("[Scan] Failed to execute Malware scan - ", err)
     await updateStatus(AttachmentsSrv, key, STATUS_FAILED, currEntity, draftEntity, activeEntity);
   }
 }
@@ -118,7 +118,7 @@ function getCredentials() {
 }
 
 function streamToString(stream) {
-  DEBUG?.(`[Scan] streaming to string`);
+  DEBUG?.(`[Scan] Streaming to string`);
   const chunks = [];
   try {
     return new Promise((resolve, reject) => {

--- a/lib/malwareScanner.js
+++ b/lib/malwareScanner.js
@@ -31,8 +31,8 @@ async function scanRequest(Attachments, key, req) {
 }
 
 async function remoteScan(key, req, currEntity, draftEntity, activeEntity) {
+  const AttachmentsSrv = await cds.connect.to("attachments");
   try {
-    const AttachmentsSrv = await cds.connect.to("attachments");
 
     DEBUG?.(`[Scan] Executing remote scan for ${currEntity.name}`);
     await updateStatus(AttachmentsSrv, key, STATUS_SCANNING, currEntity, draftEntity, activeEntity);

--- a/lib/malwareScanner.js
+++ b/lib/malwareScanner.js
@@ -91,11 +91,14 @@ async function sendFileToMalwareScanner(fileContent) {
 }
 
 async function updateStatus(AttachmentsSrv, key, status, currEntity, draftEntity, activeEntity) {
-   DEBUG?.(`[Scan] Updating status for ${currEntity} - ${status}`);
+  DEBUG?.(`[Scan] Updating status for ${currEntity} - ${status}`);
+  DEBUG?.(`[Scan] Updating status - AttachmentsSrv: ${AttachmentsSrv} | key: ${JSON.stringify(key)} | currEntity: ${currEntity} | draftEntity: ${draftEntity} | activeEntity: ${activeEntity}`);
+  
   if (currEntity == draftEntity) {
     currEntity = await getCurrentEntity(currEntity, activeEntity, key)
   }
   await AttachmentsSrv.update(currEntity, key, { status: status })
+  DEBUG?.(`[Scan] Updated status for ${currEntity} - ${status}`);
 }
 
 async function getCurrentEntity(draftEntity, activeEntity, key) {

--- a/lib/malwareScanner.js
+++ b/lib/malwareScanner.js
@@ -37,6 +37,7 @@ async function remoteScan(key, req, currEntity, draftEntity, activeEntity) {
     DEBUG?.(`[Scan] Executing remote scan for ${currEntity.name}`);
     await updateStatus(AttachmentsSrv, key, STATUS_SCANNING, currEntity, draftEntity, activeEntity);
 
+    DEBUG?.(`[Scan] currEntity ${currEntity} | key ${JSON.stringify(key)} | tenant ${JSON.stringify(req.tenant)}`);
     const contentStream = await AttachmentsSrv.get(currEntity, key, req.tenant);
     const fileContent = await streamToString(contentStream);
 

--- a/lib/malwareScanner.js
+++ b/lib/malwareScanner.js
@@ -2,6 +2,12 @@ const cds = require('@sap/cds')
 const DEBUG = cds.debug('attachments')
 const { SELECT } = cds.ql;
 
+
+const STATUS_INFECTED = "Infected";
+const STATUS_CLEAN = "Clean";
+const STATUS_SCANNING = "Scanning"; 
+const STATUS_FAILED = "Failed";
+
 async function scanRequest(Attachments, key, req) {
   DEBUG?.(`[Scan] Scanning file uploaded for ${Attachments}`);
   const scanEnabled = cds.env.requires?.attachments?.scan ?? true
@@ -14,67 +20,70 @@ async function scanRequest(Attachments, key, req) {
   } else {
     activeEntity = Attachments
   }
-  DEBUG?.(`[Scan] activeEntity = ${activeEntity}`);
   let currEntity = draftEntity == undefined ? activeEntity : draftEntity
 
+  DEBUG?.(`[Scan] activeEntity = ${activeEntity}`);
+
   if (!scanEnabled) {
-    if (cds.env.profiles.some(p => p === "development" || p === "test") && !cds.env.profiles.includes("hybrid")) {
-      await updateStatus(AttachmentsSrv, key, "Scanning", currEntity, draftEntity, activeEntity)
-      setTimeout(() => {
-        DEBUG?.('Malware scanning is disabled. Setting scan status to Clean in development profile.')
-        updateStatus(AttachmentsSrv, key, "Clean", currEntity, draftEntity, activeEntity)
-          .catch(e => cds.log('attachments').error(e))
-      }, 5000).unref()
-      return
-    } else {
-      return
+    await localMockedScan(AttachmentsSrv, key, req, currEntity, draftEntity, activeEntity);
+  } else {
+    await remoteScan(AttachmentsSrv, key, req, currEntity, draftEntity, activeEntity);
+  }
+}
+
+async function remoteScan(AttachmentsSrv, key, req, currEntity, draftEntity, activeEntity) {
+  try {
+    DEBUG?.(`[Scan] Executing remote scan for ${currEntity.name}`);
+    await updateStatus(AttachmentsSrv, key, STATUS_SCANNING, currEntity, draftEntity, activeEntity);
+
+    const contentStream = await AttachmentsSrv.get(currEntity, key);
+    const fileContent = await streamToString(contentStream);
+
+    const malwareScannerResponse = await sendFileToMalwareScanner(fileContent);
+    
+    const responseText = await malwareScannerResponse.json();
+
+    const status = responseText.malwareDetected ? STATUS_INFECTED : STATUS_CLEAN;
+
+    if (status === STATUS_INFECTED) {
+      DEBUG?.("[Scan] Malware detected in the file, deleting attachment content from db", key);
+      await AttachmentsSrv.deleteInfectedAttachment(currEntity, key, req);
     }
-  }
-
-  await updateStatus(AttachmentsSrv, key, "Scanning", currEntity, draftEntity, activeEntity)
-
-  const credentials = getCredentials()
-  const contentStream = await AttachmentsSrv.get(currEntity, key)
-  let fileContent
-  try {
-    DEBUG?.(`[Scan] streaming to string`);
-    fileContent = await streamToString(contentStream)
-  } catch (err) {
-    DEBUG?.("[Scan] Malware Scanning: Cannot read file content", err)
-    await updateStatus(AttachmentsSrv, key, "Failed", currEntity, draftEntity, activeEntity)
-    return
-  }
-
-  let response;
-  try {
-    DEBUG?.("[Scan] Sending file to Malware Scanning Service");
-    response = await fetch(`https://${credentials.uri}/scan`, {
-      method: "POST",
-      headers: {
-        Authorization:
-          "Basic " + Buffer.from(`${credentials.username}:${credentials.password}`, "binary").toString("base64"),
-      },
-      body: fileContent,
-    })
-  } catch (error) {
-    DEBUG?.("Request to malware scanner failed", error)
-    await updateStatus(AttachmentsSrv, key, "Failed", currEntity, draftEntity, activeEntity)
-    return
-  }
-
-  try {
-    const responseText = await response.json()
-    const status = responseText.malwareDetected ? "Infected" : "Clean"
     DEBUG?.(`[Scan] Scanned file with status: ${status}`, key);
-    if (status === "Infected") {
-      DEBUG?.("[Scan] Malware detected in the file, deleting attachment content from db", key)
-      await AttachmentsSrv.deleteInfectedAttachment(currEntity, key, req)
-    }
-    await updateStatus(AttachmentsSrv, key, status, currEntity, draftEntity, activeEntity)
+    await updateStatus(AttachmentsSrv, key, status, currEntity, draftEntity, activeEntity);
   } catch (err) {
-    DEBUG?.("Cannot serialize malware scanner response body", err)
-    await updateStatus(AttachmentsSrv, key, "Failed", currEntity, draftEntity, activeEntity)
+    DEBUG?.("[Scan] Failed to execute Malware scan", err)
+    await updateStatus(AttachmentsSrv, key, STATUS_FAILED, currEntity, draftEntity, activeEntity);
   }
+}
+
+async function localMockedScan(AttachmentsSrv, key, req, currEntity, draftEntity, activeEntity) {
+  DEBUG?.(`[Scan] Executing local mocked scan for ${currEntity.name}`);
+  if (cds.env.profiles.some(p => p === "development" || p === "test") && !cds.env.profiles.includes("hybrid")) {
+    await updateStatus(AttachmentsSrv, key, "Scanning", currEntity, draftEntity, activeEntity)
+    setTimeout(() => {
+      DEBUG?.('Malware scanning is disabled. Setting scan status to Clean in development profile.')
+      updateStatus(AttachmentsSrv, key, "Clean", currEntity, draftEntity, activeEntity)
+        .catch(e => cds.log('attachments').error(e))
+    }, 5000).unref()
+    return
+  } else {
+    return
+  }
+}
+
+async function sendFileToMalwareScanner(fileContent) {
+  DEBUG?.("[Scan] Sending file to Malware Scanning Service");
+  const credentials = getCredentials();
+  response = await fetch(`https://${credentials.uri}/scan`, {
+    method: "POST",
+    headers: {
+      Authorization:
+        "Basic " + Buffer.from(`${credentials.username}:${credentials.password}`, "binary").toString("base64"),
+    },
+    body: fileContent,
+  });
+  return response;
 }
 
 async function updateStatus(AttachmentsSrv, key, status, currEntity, draftEntity, activeEntity) {
@@ -103,11 +112,12 @@ function getCredentials() {
   try {
     return cds.env.requires.malwareScanner.credentials;
   } catch {
-    throw new Error("SAP Malware Scanning service is not bound.");
+    throw new Error("[Scan] SAP Malware Scanning service is not bound.");
   }
 }
 
 function streamToString(stream) {
+  DEBUG?.(`[Scan] streaming to string`);
   const chunks = [];
   try {
     return new Promise((resolve, reject) => {

--- a/lib/malwareScanner.js
+++ b/lib/malwareScanner.js
@@ -26,7 +26,7 @@ async function scanRequest(Attachments, key, req) {
   if (!scanEnabled) {
     await localMockedScan(key, req, currEntity, draftEntity, activeEntity);
   } else {
-    remoteScan(key, req, currEntity, draftEntity, activeEntity);
+    await remoteScan(key, req, currEntity, draftEntity, activeEntity);
   }
 }
 
@@ -35,9 +35,8 @@ async function remoteScan(key, req, currEntity, draftEntity, activeEntity) {
   try {
 
     DEBUG?.(`[Scan] Executing remote scan for ${currEntity.name}`);
-    await updateStatus(AttachmentsSrv, key, STATUS_SCANNING, currEntity, draftEntity, activeEntity);
+    await updateStatus(key, STATUS_SCANNING, currEntity, draftEntity, activeEntity);
 
-    DEBUG?.(`[Scan] currEntity ${currEntity} | key ${JSON.stringify(key)} | tenant ${JSON.stringify(req.tenant)}`);
     const contentStream = await AttachmentsSrv.get(currEntity, key, req.tenant);
     const fileContent = await streamToString(contentStream);
 
@@ -52,10 +51,10 @@ async function remoteScan(key, req, currEntity, draftEntity, activeEntity) {
       await AttachmentsSrv.deleteInfectedAttachment(currEntity, key, req);
     }
     DEBUG?.(`[Scan] Scanned file with status: ${status}`, key);
-    await updateStatus(AttachmentsSrv, key, status, currEntity, draftEntity, activeEntity);
+    await updateStatus(key, status, currEntity, draftEntity, activeEntity);
   } catch (err) {
     DEBUG?.("[Scan] Failed to execute Malware scan - ", err)
-    await updateStatus(AttachmentsSrv, key, STATUS_FAILED, currEntity, draftEntity, activeEntity);
+    await updateStatus(key, STATUS_FAILED, currEntity, draftEntity, activeEntity);
   }
 }
 
@@ -64,10 +63,10 @@ async function localMockedScan(key, req, currEntity, draftEntity, activeEntity) 
 
   DEBUG?.(`[Scan] Executing local mocked scan for ${currEntity.name}`);
   if (cds.env.profiles.some(p => p === "development" || p === "test") && !cds.env.profiles.includes("hybrid")) {
-    await updateStatus(AttachmentsSrv, key, "Scanning", currEntity, draftEntity, activeEntity)
+    await updateStatus(key, "Scanning", currEntity, draftEntity, activeEntity)
     setTimeout(() => {
       DEBUG?.('Malware scanning is disabled. Setting scan status to Clean in development profile.')
-      updateStatus(AttachmentsSrv, key, "Clean", currEntity, draftEntity, activeEntity)
+      updateStatus(key, "Clean", currEntity, draftEntity, activeEntity)
         .catch(e => cds.log('attachments').error(e))
     }, 5000).unref()
     return
@@ -90,15 +89,13 @@ async function sendFileToMalwareScanner(fileContent) {
   return response;
 }
 
-async function updateStatus(AttachmentsSrv, key, status, currEntity, draftEntity, activeEntity) {
-  DEBUG?.(`[Scan] Updating status for ${currEntity} - ${status}`);
-  DEBUG?.(`[Scan] Updating status - AttachmentsSrv: ${JSON.stringify(AttachmentsSrv)} | key: ${JSON.stringify(key)} | currEntity: ${currEntity} | draftEntity: ${draftEntity} | activeEntity: ${activeEntity}`);
-  
+async function updateStatus(key, status, currEntity, draftEntity, activeEntity) {
+  DEBUG?.(`[Scan] Updating status for ${currEntity} - ${status}`);  
   if (currEntity == draftEntity) {
     currEntity = await getCurrentEntity(currEntity, activeEntity, key)
   }
   const entityName = typeof currEntity === 'string' ? currEntity : currEntity.name;
-  await AttachmentsSrv.update(entityName, key, { status: status })
+  await cds.update(entityName, key, { status: status })
   DEBUG?.(`[Scan] Updated status for ${entityName} - ${status}`);
 }
 


### PR DESCRIPTION
This PR:
* Refactors the implementation of Malware Scanner
* Adds logs
* Triggers the scanRequest using [cds.spawn](https://cap.cloud.sap/docs/node.js/cds-tx#cds-spawn)

Attention:
* This PR is based on the branch `fix/non-draft_mtls_upload`
* This PR still does not fix the issue of uploading - basically when doing a trigger, during the change of the status on the Attachment entity to `Scanning`, the request fails and the server crash and the server restarts. Filtered logs here 
[filtered-logs.txt](https://github.com/user-attachments/files/22050268/filtered-logs.txt)