### PR TITLE
Fix: S3 hybrid mode should accept HTTP requests

### DIFF
--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -175,12 +175,11 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
       await this.createClientS3(tenantID);
     }
 
-    const targetID = req.data.ID || req.params[1]?.ID || req.params[1];
-    if (!targetID) {
-      req.reject(400, "Missing ID in request");
-    }
-
     if (req?.data?.content) {
+      const targetID = req.data.ID || req.params[1]?.ID || req.params[1];
+      if (!targetID) {
+        req.reject(400, "Missing ID in request");
+      }
       const response = await SELECT.from(req.target, { ID: targetID }).columns("url");
       if (response?.url) {
         const Key = response.url;
@@ -201,6 +200,10 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
         DEBUG?.(`[S3 Upload] Uploaded file using updateContentHandler for ${req.target.name}`);
       }
     } else if (req?.data?.note) {
+      const targetID = req.data.ID || req.params[1]?.ID || req.params[1];
+      if (!targetID) {
+        req.reject(400, "Missing ID in request");
+      }
       const key = { ID: targetID };
       await super.update(req.target, key, { note: req.data.note });
       DEBUG?.(`[S3 Upload] Updated file upload with note for ${req.target.name}`);

--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -175,12 +175,11 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
       await this.createClientS3(tenantID);
     }
 
-    const targetID = req?.data?.ID || req?.params[1]?.ID || req?.params[1];
-    if (!targetID) {
-      req.reject(400, "Missing ID in request");
-    }
-
     if (req?.data?.content) {
+      const targetID = req.data.ID || req.params[1]?.ID || req.params[1];
+      if (!targetID) {
+        req.reject(400, "Missing ID in request");
+      }
       const response = await SELECT.from(req.target, { ID: targetID }).columns("url");
       if (response?.url) {
         const Key = response.url;
@@ -201,6 +200,10 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
         DEBUG?.(`[S3 Upload] Uploaded file using updateContentHandler for ${req.target.name}`);
       }
     } else if (req?.data?.note) {
+      const targetID = req.data.ID || req.params[1]?.ID || req.params[1];
+      if (!targetID) {
+        req.reject(400, "Missing ID in request");
+      }
       const key = { ID: targetID };
       await super.update(req.target, key, { note: req.data.note });
       DEBUG?.(`[S3 Upload] Updated file upload with note for ${req.target.name}`);

--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -175,8 +175,13 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
       await this.createClientS3(tenantID);
     }
 
+    const targetID = req.data.ID || req.params[1]?.ID || req.params[1];
+    if (!targetID) {
+      req.reject(400, "Missing ID in request");
+    }
+
     if (req?.data?.content) {
-      const response = await SELECT.from(req.target, { ID: req.data.ID || req.params[1]?.ID || req.params[1] }).columns("url");
+      const response = await SELECT.from(req.target, { ID: targetID }).columns("url");
       if (response?.url) {
         const Key = response.url;
         const input = {
@@ -191,12 +196,12 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
         // const stored = super.put (Attachments, metadata)
         await Promise.all([multipartUpload.done()]);
 
-        const keys = { ID: req.data.ID || req.params[1]?.ID || req.params[1] }
+        const keys = { ID: targetID }
         scanRequest(req.target, keys, req)
         DEBUG?.(`[S3 Upload] Uploaded file using updateContentHandler for ${req.target.name}`);
       }
     } else if (req?.data?.note) {
-      const key = { ID: req.data.ID || req.params[1]?.ID || req.params[1] };
+      const key = { ID: targetID };
       await super.update(req.target, key, { note: req.data.note });
       DEBUG?.(`[S3 Upload] Updated file upload with note for ${req.target.name}`);
     } else {

--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -175,11 +175,12 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
       await this.createClientS3(tenantID);
     }
 
+    const targetID = req?.data?.ID || req?.params[1]?.ID || req?.params[1];
+    if (!targetID) {
+      req.reject(400, "Missing ID in request");
+    }
+
     if (req?.data?.content) {
-      const targetID = req.data.ID || req.params[1]?.ID || req.params[1];
-      if (!targetID) {
-        req.reject(400, "Missing ID in request");
-      }
       const response = await SELECT.from(req.target, { ID: targetID }).columns("url");
       if (response?.url) {
         const Key = response.url;
@@ -200,10 +201,6 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
         DEBUG?.(`[S3 Upload] Uploaded file using updateContentHandler for ${req.target.name}`);
       }
     } else if (req?.data?.note) {
-      const targetID = req.data.ID || req.params[1]?.ID || req.params[1];
-      if (!targetID) {
-        req.reject(400, "Missing ID in request");
-      }
       const key = { ID: targetID };
       await super.update(req.target, key, { note: req.data.note });
       DEBUG?.(`[S3 Upload] Updated file upload with note for ${req.target.name}`);

--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -176,7 +176,7 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
     }
 
     if (req?.data?.content) {
-      const response = await SELECT.from(req.target, { ID: req.data.ID }).columns("url");
+      const response = await SELECT.from(req.target, { ID: req.data.ID || req.params[1]?.ID || req.params[1] }).columns("url");
       if (response?.url) {
         const Key = response.url;
         const input = {
@@ -191,12 +191,12 @@ module.exports = class AWSAttachmentsService extends require("./basic") {
         // const stored = super.put (Attachments, metadata)
         await Promise.all([multipartUpload.done()]);
 
-        const keys = { ID: req.data.ID }
+        const keys = { ID: req.data.ID || req.params[1]?.ID || req.params[1] }
         scanRequest(req.target, keys, req)
         DEBUG?.(`[S3 Upload] Uploaded file using updateContentHandler for ${req.target.name}`);
       }
     } else if (req?.data?.note) {
-      const key = { ID: req.data.ID };
+      const key = { ID: req.data.ID || req.params[1]?.ID || req.params[1] };
       await super.update(req.target, key, { note: req.data.note });
       DEBUG?.(`[S3 Upload] Updated file upload with note for ${req.target.name}`);
     } else {

--- a/tests/non-draft-request.http
+++ b/tests/non-draft-request.http
@@ -20,15 +20,19 @@ Content-Type: application/json
 }
 
 ### Put attachment content (content request)
-@newAttachmentID = {{createAttachment.response.body.ID}}
-PUT {{host}}/odata/v4/processor/Incidents({{incidentsID}})/attachments(ID={{newAttachmentID}})/content
+@attachmentsID = {{createAttachment.response.body.ID}}
+PUT {{host}}/odata/v4/processor/Incidents({{incidentsID}})/attachments(ID={{attachmentsID}})/content
 Authorization: {{auth}}
 Content-Type: image/jpeg
 
 < ./integration/content/sample-1.jpg
 
+###
+GET {{host}}/odata/v4/processor/Incidents({{incidentsID}})/attachments(ID={{attachmentsID}})
+Authorization: {{auth}}
+
 ### Fetching newly created attachment content
-GET {{host}}/odata/v4/processor/Incidents({{incidentsID}})/attachments(ID={{newAttachmentID}})/content
+GET {{host}}/odata/v4/processor/Incidents({{incidentsID}})/attachments(ID={{attachmentsID}})/content
 Authorization: {{auth}}
 
 ### Get list of attachments for a particular incident
@@ -37,22 +41,15 @@ GET {{host}}/odata/v4/processor/Incidents(ID={{incidentsID}})/attachments
 Authorization: {{auth}}
 
 ### Get attachments content
-@attachmentsID = {{attachments.response.body.value[0].ID}}
 GET {{host}}/odata/v4/processor/Incidents({{incidentsID}})/attachments(ID={{attachmentsID}})/content
 Authorization: {{auth}}
 
 ### Get attachments content with up__ID included
-@incidentID = {{attachments.response.body.value[0].up__ID}}
-GET {{host}}/odata/v4/processor/Incidents({{incidentsID}})/attachments(up__ID={{incidentID}},ID={{attachmentsID}})/content
-Authorization: {{auth}}
-
-### Fetching newly created attachment content with up__ID included
-GET {{host}}/odata/v4/processor/Incidents({{incidentsID}})/attachments(up__ID={{incidentID}},ID={{attachmentsID}})/content
+GET {{host}}/odata/v4/processor/Incidents({{incidentsID}})/attachments(up__ID={{incidentsID}},ID={{attachmentsID}})/content
 Authorization: {{auth}}
 
 ### Put attachment content (content request) with up__ID included
-@newAttachmentID = {{createAttachment.response.body.ID}}
-PUT {{host}}/odata/v4/processor/Incidents({{incidentsID}})/attachments(up__ID={{incidentID}},ID={{attachmentsID}})/content
+PUT {{host}}/odata/v4/processor/Incidents({{incidentsID}})/attachments(up__ID={{incidentsID}},ID={{attachmentsID}})/content
 Authorization: {{auth}}
 Content-Type: image/jpeg
 

--- a/tests/non-draft-request.http
+++ b/tests/non-draft-request.http
@@ -27,7 +27,7 @@ Content-Type: image/jpeg
 
 < ./integration/content/sample-1.jpg
 
-###
+### Get newly created attachment metadata
 GET {{host}}/odata/v4/processor/Incidents({{incidentsID}})/attachments(ID={{attachmentsID}})
 Authorization: {{auth}}
 


### PR DESCRIPTION
Found that when using HTTP requests in hybrid mode that the value of ID was put into req.params so when we tried using it to start scanning, ID could not be found. Have now adjusted the keys to reflect the possibility of multiple locations where the ID could be for both draft and non-draft mode. 

Also cleaned up the http requests file.