### PR TITLE
Fix redundant creation of object stores

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -4,6 +4,7 @@ const crypto = require("crypto")
 const stream = require('stream/promises')
 const { logConfig } = require('./logger')
 const cds = require('@sap/cds')
+const LOG = cds.log("attachments")
 
 /**
  * Validates the presence of required Service Manager credentials
@@ -58,18 +59,34 @@ function validateInputs(tenantID, sm_url, token) {
 
 /**
  * Fetches object store service binding from Service Manager
- * @param {string} sm_url - Service Manager URL
  * @param {string} tenantID - Tenant ID
- * @param {string} token - Access token
+ * @param {string?} token - Access token, if nothing is provided access token is fetched
  * @returns {Promise<Array>} - Promise resolving to array of service bindings
  */
-async function fetchObjectStoreBinding(sm_url, tenantID, token) {
-  logConfig.debug('Making Service Manager API call', {
+async function fetchObjectStoreBinding(tenantID, token) {
+  const serviceManagerCreds = cds.env.requires?.serviceManager?.credentials
+
+  validateServiceManagerCredentials(serviceManagerCreds)
+
+   const { sm_url, url, clientid, clientsecret, certificate, key, certurl } = serviceManagerCreds
+
+   
+   if (!token) {
+     LOG.debug('Fetching access token for tenant', { tenantID, sm_url: sm_url })
+     token = await fetchToken(url, clientid, clientsecret, certificate, key, certurl)
+   }
+   
+   LOG.debug('Fetching object store credentials', { tenantID, sm_url })
+   
+   if (!validateInputs(tenantID, sm_url, token)) {
+     return null
+    }
+    
+  LOG.debug('Making Service Manager API call', {
     tenantID,
     endpoint: `${sm_url}/v1/service_bindings`,
     labelQuery: `service eq 'OBJECT_STORE' and tenant_id eq '${tenantID}'`
   })
-
   const response = await axios.get(`${sm_url}/v1/service_bindings`, {
     params: { labelQuery: `service eq 'OBJECT_STORE' and tenant_id eq '${tenantID}'` },
     headers: {
@@ -88,23 +105,8 @@ async function fetchObjectStoreBinding(sm_url, tenantID, token) {
  * @returns {Promise<Object|null>} - Promise resolving to object store credentials or null
  */
 async function getObjectStoreCredentials(tenantID) {
-  const serviceManagerCreds = cds.env.requires?.serviceManager?.credentials
-
-  validateServiceManagerCredentials(serviceManagerCreds)
-
-  const { sm_url, url, clientid, clientsecret, certificate, key, certurl } = serviceManagerCreds
-
-  logConfig.debug('Fetching access token for tenant', { tenantID, sm_url: sm_url })
-  const token = await fetchToken(url, clientid, clientsecret, certificate, key, certurl)
-
-  logConfig.processStep('Fetching object store credentials', { tenantID, sm_url })
-
-  if (!validateInputs(tenantID, sm_url, token)) {
-    return null
-  }
-
   try {
-    const items = await fetchObjectStoreBinding(sm_url, tenantID, token)
+    const items = await fetchObjectStoreBinding(tenantID)
 
     if (!items.length) {
       logConfig.withSuggestion('error', `No object store service binding found for tenant`, null,
@@ -130,7 +132,6 @@ async function getObjectStoreCredentials(tenantID) {
 
     logConfig.withSuggestion('error', 'Failed to fetch object store credentials', error, suggestion, {
       tenantID,
-      sm_url,
       httpStatus: error.response?.status,
       responseData: error.response?.data
     })
@@ -308,5 +309,7 @@ async function computeHash(input) {
 module.exports = {
   fetchToken,
   getObjectStoreCredentials,
-  computeHash
+  computeHash,
+  fetchObjectStoreBinding,
+  validateServiceManagerCredentials
 }

--- a/lib/mtx/server.js
+++ b/lib/mtx/server.js
@@ -1,10 +1,11 @@
 const cds = require('@sap/cds')
+const LOG = cds.log('attachments')
 const axios = require('axios')
 const https = require("https")
-const { logConfig } = require('../logger')
 const { S3Client, paginateListObjectsV2, DeleteObjectsCommand } = require('@aws-sdk/client-s3')
 const { BlobServiceClient } = require('@azure/storage-blob')
 const { Storage } = require('@google-cloud/storage')
+const { validateServiceManagerCredentials, fetchObjectStoreBinding } = require('../helper')
 
 const PATH = {
     SERVICE_INSTANCE: "v1/service_instances",
@@ -65,32 +66,10 @@ const _serviceManagerRequest = async (sm_url, method, path, token, params = {}) 
         return response?.data?.items?.[0] // Error handling : return undefined instead of crashing when .items is undefined
 
     } catch (error) {
-        logConfig.withSuggestion('error',
-            `Service Manager API request failed - ${method.toUpperCase()} ${path}`, error,
+        LOG.error(`Service Manager API request failed - ${method.toUpperCase()} ${path}`, error,
             'Check Service Manager connectivity and credentials',
             { method, path, sm_url, params })
         throw error
-    }
-}
-
-/**
- * Registers attachment handlers for the given service and entity
- * @param {{ sm_url: string, url: string, clientid: string, clientsecret: string, certificate: string, key: string }} param0 - Service Manager credentials
- */
-const _validateSMCredentials = ({ sm_url, url, clientid, clientsecret, certificate, key }) => {
-    if (!sm_url || !url) {
-        throw new Error("Missing Service Manager credentials: 'sm_url' or 'url' is not defined.")
-    }
-
-    if (!clientid || !clientsecret) {
-        logConfig.debug('OAuth client credentials not found - checking for MTLS credentials', { sm_url, url, clientid })
-        if (!certificate || !key) {
-            logConfig.withSuggestion('error',
-                'MTLS credentials are also missing', null,
-                'Provide either OAuth clientid/clientsecret or MTLS certificate/key in Service Manager credentials',
-                { sm_url, url, clientid })
-            throw new Error("MTLS credentials are also missing: 'certificate' or 'key' is not defined.")
-        }
     }
 }
 
@@ -105,7 +84,7 @@ const _fetchToken = async (url, clientid, clientsecret, certificate, key) => {
 
         // Case 1: OAuth Client Credentials Flow
         if (clientid && clientsecret) {
-            logConfig.debug('Using OAuth client credentials to fetch token.', { url, clientid })
+            LOG.debug('Using OAuth client credentials to fetch token.', { url, clientid })
             const response = await axios.post(tokenUrl, null, {
                 headers,
                 params: {
@@ -116,7 +95,7 @@ const _fetchToken = async (url, clientid, clientsecret, certificate, key) => {
             })
 
             if (!response.data?.access_token) {
-                logConfig.withSuggestion('error', 'OAuth token response missing access_token', null,
+                LOG.error('OAuth token response missing access_token', null,
                     'Check clientid/clientsecret validity and Service Manager configuration',
                     { clientid, responseData: response.data })
                 throw new Error('Access token not found in OAuth token response')
@@ -125,11 +104,11 @@ const _fetchToken = async (url, clientid, clientsecret, certificate, key) => {
             return response.data.access_token
         }
 
-        logConfig.debug('OAuth client credentials missing - checking for MTLS credentials', { url, clientid })
+        LOG.debug('OAuth client credentials missing - checking for MTLS credentials', { url, clientid })
 
         // Case 2: MTLS Flow
         if (certificate && key) {
-            logConfig.debug('MTLS certificate and key found - proceeding with MTLS token fetch.', { url, clientid })
+            LOG.debug('MTLS certificate and key found - proceeding with MTLS token fetch.', { url, clientid })
             const agent = new https.Agent({ cert: certificate, key: key })
 
             const response = await axios.post(tokenUrl, body, {
@@ -138,7 +117,7 @@ const _fetchToken = async (url, clientid, clientsecret, certificate, key) => {
             })
 
             if (!response.data?.access_token) {
-                logConfig.withSuggestion('error', 'MTLS token response missing access_token', null,
+                LOG.error('MTLS token response missing access_token', null,
                     'Check MTLS certificate/key validity and Service Manager configuration',
                     { clientid, responseData: response.data })
                 throw new Error('Access token not found in MTLS token response')
@@ -150,8 +129,7 @@ const _fetchToken = async (url, clientid, clientsecret, certificate, key) => {
         // If neither flow is possible
         throw new Error("Missing authentication credentials: Provide either OAuth clientid/clientsecret or MTLS certificate/key.")
     } catch (error) {
-        logConfig.withSuggestion('error',
-            'Failed to fetch OAuth token using provided credentials', error,
+        LOG.error('Failed to fetch OAuth token using provided credentials', error,
             'Verify Service Manager credentials and connectivity')
         throw error
     }
@@ -160,7 +138,7 @@ const _fetchToken = async (url, clientid, clientsecret, certificate, key) => {
 const _getOfferingID = async (sm_url, token) => {
     const offerings = await _serviceManagerRequest(sm_url, HTTP_METHOD.GET, PATH.SERVICE_OFFERING, token, { fieldQuery: "name eq 'objectstore'" })
     const offeringID = offerings.id
-    if (!offeringID) logConfig.debug('Object store service offering not found in Service Manager', { sm_url })
+    if (!offeringID) LOG.debug('Object store service offering not found in Service Manager', { sm_url })
     return offeringID
 }
 
@@ -175,7 +153,7 @@ const _getPlanID = async (sm_url, token, offeringID) => {
     // Recheck the fieldQuery for catalog_name
     const supportedPlans = ["standard", "s3-standard"]
     for (const planName of supportedPlans) {
-        logConfig.debug('Fetching object store plan from Service Manager', { planName })
+        LOG.debug('Fetching object store plan from Service Manager', { planName })
         try {
             const plan = await _serviceManagerRequest(
                 sm_url,
@@ -187,18 +165,17 @@ const _getPlanID = async (sm_url, token, offeringID) => {
                 }
             )
             if (plan?.id) {
-                logConfig.debug('Using object store plan', { planName, planID: plan.id, offeringID })
+                LOG.debug('Using object store plan', { planName, planID: plan.id, offeringID })
                 return plan.id
             }
         } catch (error) {
-            logConfig.withSuggestion('error',
-                `Failed to fetch plan "${planName}" from Service Manager`, error,
+            LOG.error(`Failed to fetch plan "${planName}" from Service Manager`, error,
                 'Check Service Manager connectivity and credentials',
                 { sm_url, offeringID, planName })
             throw error
         }
     }
-    logConfig.debug('No supported object store service plan found in Service Manager', { sm_url, attempted: supportedPlans.join(", ") })
+    LOG.debug('No supported object store service plan found in Service Manager', { sm_url, attempted: supportedPlans.join(", ") })
     throw new Error(
         `No supported object store service plan found in Service Manager.`
     )
@@ -230,8 +207,7 @@ const _createObjectStoreInstance = async (sm_url, tenant, planID, token) => {
         const instanceId = await _pollUntilDone(sm_url, instancePath, token)
         return instanceId.data.resource_id
     } catch (error) {
-        logConfig.withSuggestion('error',
-            `Failed to create object store instance for tenant - ${tenant}`, error,
+        LOG.error(`Failed to create object store instance for tenant - ${tenant}`, error,
             'Check Service Manager connectivity and credentials',
             { sm_url, tenant, planID })
     }
@@ -263,16 +239,15 @@ const _pollUntilDone = async (sm_url, instancePath, token) => {
             }
 
             if (Date.now() - startTime > ASYNC_TIMEOUT) {
-                logConfig.debug('Timed out waiting for service instance to be ready', { instancePath, sm_url })
+                LOG.debug('Timed out waiting for service instance to be ready', { instancePath, sm_url })
             }
 
             if (instanceStatus.data.state === STATE.FAILED) {
-                logConfig.debug('Service instance creation failed', { instancePath, sm_url, details: instanceStatus.data })
+                LOG.debug('Service instance creation failed', { instancePath, sm_url, details: instanceStatus.data })
             }
         }
     } catch (error) {
-        logConfig.withSuggestion('error',
-            'Error polling for object store instance readiness', error,
+        LOG.error('Error polling for object store instance readiness', error,
             'Check Service Manager connectivity and instance status',
             { sm_url, instancePath })
     }
@@ -303,8 +278,7 @@ const _bindObjectStoreInstance = async (sm_url, tenant, instanceID, token) => {
             })
             return response.data.id
         } catch (error) {
-            logConfig.withSuggestion('error',
-                `Error binding object store instance for tenant - ${tenant}`, error,
+            LOG.error(`Error binding object store instance for tenant - ${tenant}`, error,
                 'Check Service Manager connectivity and credentials',
                 { sm_url, tenant, instanceID })
         }
@@ -324,14 +298,13 @@ const _getBindingIdForDeletion = async (sm_url, tenant, token) => {
             labelQuery: `service eq 'OBJECT_STORE' and tenant_id eq '${tenant}'`
         })
         if (!getBindingCredentials?.id) {
-            logConfig.warn('No binding credentials found for tenant during deletion', { tenant })
+            LOG.warn('No binding credentials found for tenant during deletion', { tenant })
             return null // Handle missing data gracefully
         }
         return getBindingCredentials.id
 
     } catch (error) {
-        logConfig.withSuggestion('error',
-            `Error fetching binding credentials for tenant - ${tenant}`, error,
+        LOG.error(`Error fetching binding credentials for tenant - ${tenant}`, error,
             'Check Service Manager connectivity and credentials',
             { sm_url, tenant })
     }
@@ -350,13 +323,12 @@ const _deleteBinding = async (sm_url, bindingID, token) => {
                 headers: { 'Accept': 'application/json', 'Authorization': `Bearer ${token}` }
             })
         } catch (error) {
-            logConfig.withSuggestion('error',
-                `Error deleting binding - ${bindingID}`, error,
+            LOG.error(`Error deleting binding - ${bindingID}`, error,
                 'Check Service Manager connectivity and credentials',
                 { sm_url, bindingID })
         }
     } else {
-        logConfig.warn('No binding ID provided for deletion, skipping delete operation')
+        LOG.warn('No binding ID provided for deletion, skipping delete operation')
     }
 }
 
@@ -372,8 +344,7 @@ const _getInstanceIdForDeletion = async (sm_url, tenant, token) => {
         const instanceId = await _serviceManagerRequest(sm_url, HTTP_METHOD.GET, PATH.SERVICE_INSTANCE, token, { labelQuery: `service eq 'OBJECT_STORE' and tenant_id eq '${tenant}'` })
         return instanceId.id
     } catch (error) {
-        logConfig.withSuggestion('error',
-            `Error fetching service instance id for tenant - ${tenant}`, error,
+        LOG.error(`Error fetching service instance id for tenant - ${tenant}`, error,
             'Check Service Manager connectivity and credentials',
             { sm_url, tenant })
     }
@@ -393,9 +364,9 @@ const _deleteObjectStoreInstance = async (sm_url, instanceID, token) => {
             })
             const instancePath = response.headers.get("location").substring(1)
             await _pollUntilDone(sm_url, instancePath, token) // remove
-            logConfig.debug('Object store instance deleted', { instanceID })
+            LOG.debug('Object store instance deleted', { instanceID })
         } catch (error) {
-            logConfig.withSuggestion('error',
+            LOG.error(
                 `Error deleting object store instance - ${instanceID}`, error,
                 'Check Service Manager connectivity and credentials',
                 { sm_url, instanceID })
@@ -413,23 +384,27 @@ cds.on('listening', async () => {
                 const { tenant } = req.data
                 try {
                     const serviceManagerCredentials = cds.env.requires?.serviceManager?.credentials || {}
+                    validateServiceManagerCredentials(serviceManagerCredentials)
                     const { sm_url, url, clientid, clientsecret, certificate, key } = serviceManagerCredentials
-
-                    _validateSMCredentials({ sm_url, url, clientid, clientsecret, certificate, key })
 
                     const token = await _fetchToken(url, clientid, clientsecret, certificate, key)
 
-                    const offeringID = await _getOfferingID(sm_url, token)
+                    const existingTenantBindings = await fetchObjectStoreBinding(tenant, token);
 
+                    if (existingTenantBindings.length) {
+                        LOG.info(`Existing tenant specific object store for ${tenant} exists. Skipping creation of new one.`)
+                        return;
+                    }
+
+                    const offeringID = await _getOfferingID(sm_url, token)
                     const planID = await _getPlanID(sm_url, token, offeringID)
 
                     const instanceID = await _createObjectStoreInstance(sm_url, tenant, planID, token)
-                    logConfig.debug('Object Store instance created', { tenant, instanceID })
+                    LOG.debug('Object Store instance created', { tenant, instanceID })
 
                     await _bindObjectStoreInstance(sm_url, tenant, instanceID, token)
                 } catch (error) {
-                    logConfig.withSuggestion('error',
-                        `Error setting up object store for tenant - ${tenant}`, error,
+                    LOG.error(`Error setting up object store for tenant - ${tenant}`, error,
                         'Check Service Manager connectivity and credentials',
                         { tenant })
                 }
@@ -439,9 +414,9 @@ cds.on('listening', async () => {
                 const { tenant } = req.data
                 try {
                     const serviceManagerCredentials = cds.env.requires?.serviceManager?.credentials || {}
-                    const { sm_url, url, clientid, clientsecret, certificate, key } = serviceManagerCredentials
+                    validateServiceManagerCredentials(serviceManagerCredentials)
 
-                    _validateSMCredentials({ sm_url, url, clientid, clientsecret, certificate, key })
+                    const { sm_url, url, clientid, clientsecret, certificate, key } = serviceManagerCredentials
 
                     const token = await _fetchToken(url, clientid, clientsecret, certificate, key)
 
@@ -453,7 +428,7 @@ cds.on('listening', async () => {
 
                     await _deleteObjectStoreInstance(sm_url, service_instance_id, token)
                 } catch (error) {
-                    logConfig.withSuggestion('error',
+                    LOG.error(
                         `Error deleting object store service for tenant - ${tenant}`, error,
                         'Check Service Manager connectivity and credentials',
                         { tenant })
@@ -478,7 +453,7 @@ cds.on('listening', async () => {
                         await _cleanupGoogleCloudObjects(creds, tenant)
                         break
                     default:
-                        logConfig.warn('Unsupported object store kind for cleanup', { kind: cds.env.requires?.attachments?.kind, tenant })
+                        LOG.warn('Unsupported object store kind for cleanup', { kind: cds.env.requires?.attachments?.kind, tenant })
                 }
             })
 
@@ -521,12 +496,12 @@ const _cleanupAWSS3Objects = async (creds, tenant) => {
                 Bucket: bucket,
                 Delete: { Objects: keysToDelete },
             }))
-            logConfig.debug('[AWS S3] S3 objects deleted for tenant', { tenant, deletedCount: keysToDelete.length })
+            LOG.debug('[AWS S3] S3 objects deleted for tenant', { tenant, deletedCount: keysToDelete.length })
         } else {
-            logConfig.debug('[AWS S3] No S3 objects found for tenant during cleanup', { tenant })
+            LOG.debug('[AWS S3] No S3 objects found for tenant during cleanup', { tenant })
         }
     } catch (error) {
-        logConfig.withSuggestion('error',
+        LOG.error(
             `Failed to clean up S3 objects for tenant "${tenant}"`, error,
             'Check AWS S3 connectivity and permissions',
             { tenant })
@@ -553,9 +528,9 @@ const _cleanupAzureBlobObjects = async (creds, tenant) => {
             await blockBlobClient.delete()
         }
 
-        logConfig.debug('[Azure] Azure Blob objects deleted for tenant', { tenant, deletedCount: blobsToDelete.length })
+        LOG.debug('[Azure] Azure Blob objects deleted for tenant', { tenant, deletedCount: blobsToDelete.length })
     } catch (error) {
-        logConfig.withSuggestion('error',
+        LOG.error(
             `Failed to clean up Azure Blob objects for tenant "${tenant}"`, error,
             'Check Azure Blob Storage connectivity and permissions',
             { tenant })
@@ -590,9 +565,9 @@ const _cleanupGoogleCloudObjects = async (creds, tenant) => {
             pageToken = nextQuery?.pageToken
         } while (pageToken)
 
-        logConfig.debug('[GCP] Google Cloud Storage objects deleted for tenant', { tenant, deletedCount: totalDeleted })
+        LOG.debug('[GCP] Google Cloud Storage objects deleted for tenant', { tenant, deletedCount: totalDeleted })
     } catch (error) {
-        logConfig.withSuggestion('error',
+        LOG.error(
             `Failed to clean up Google Cloud Platform objects for tenant "${tenant}"`, error,
             'Check Google Cloud Storage connectivity and permissions',
             { tenant })
@@ -601,7 +576,6 @@ const _cleanupGoogleCloudObjects = async (creds, tenant) => {
 
 module.exports = {
     _fetchToken,
-    _validateSMCredentials,
     _serviceManagerRequest,
     _getOfferingID,
     _getPlanID,


### PR DESCRIPTION
The "subscribe" event from the MTX Deployment Service is send also when in the SaaS manager a subscription is updated. With this PR the handler is skipped in case of an existing object store for the tenant.