### PR TITLE
Enhance note field in Attachments aspect to support multi-line text

### DIFF
--- a/db/index.cds
+++ b/db/index.cds
@@ -34,7 +34,7 @@ context sap.attachments {
   }
 
   aspect Attachments : cuid, managed, MediaData {
-    note : String @title: '{i18n>Note}';
+    note : String  @title: '{i18n>Note}'  @UI.MultiLineText;
   }
 
 


### PR DESCRIPTION
# Enhance note field in Attachments aspect to support multi-line text

### Changes

📝 **Documentation**: Updated the `note` field in the `Attachments` aspect to enable multi-line text input for better user experience when adding attachment descriptions.

### Changes

* `db/index.cds`: Added `@UI.MultiLineText` annotation to the `note` field in the `Attachments` aspect, allowing users to enter longer, formatted notes across multiple lines.

- [ ] 🔄 Regenerate and Update Summary

