### PR TITLE
Fix condition for PR approval check in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   requires-approval:
     runs-on: ubuntu-latest
     name: "Waiting for PR approval as this workflow runs on pull_request_target"
-    if: github.event_name == 'pull_request_target' && github.event.pull_request.base.user.login != 'cap-js'
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.owner.login != 'cap-js'
     environment: pr-approval
     steps:
       - name: Approval Step
@@ -26,18 +26,18 @@ jobs:
       matrix:
         node-version: [20.x, 22.x]
     steps:
-    - uses: actions/checkout@v5
-      with:
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm i -g @sap/cds-dk
-    - run: npm i
-    - run: cd tests/incidents-app && npm i
-    - run: npm run test
-    
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm i -g @sap/cds-dk
+      - run: npm i
+      - run: cd tests/incidents-app && npm i
+      - run: npm run test
+
   integration-tests:
     runs-on: ubuntu-latest
     needs: requires-approval


### PR DESCRIPTION
# Fix PR Approval Check in CI Workflow

### 🐛 Bug Fix

Corrected the condition logic for the PR approval check in the CI workflow to properly identify external pull requests.

### Changes

* `.github/workflows/test.yml`: 
  - Fixed the conditional check from `github.event.pull_request.base.user.login` to `github.event.pull_request.head.repo.owner.login` to correctly determine if a PR originates from outside the `cap-js` organization
  - Applied proper indentation formatting to the test job steps for improved readability and consistency

### Technical Details

The previous condition checked the base repository's user login, which would always reference the target repository owner. The corrected condition now checks the head repository's owner login, properly identifying whether a pull request comes from a fork or external contributor. This ensures that PRs from external sources require manual approval before the `pull_request_target` workflow executes, maintaining security best practices.

- [ ] 🔄 Regenerate and Update Summary

