### PR TITLE
Update CHANGELOG for version 3.6.1 and bump version in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 3.6.1
+
+### Fixed
+
+- Resolved an issue where URLs for nested entities were not generated.
+- Fixed an internal server error in CDS 8 caused by the absence of `cds.infer?.target`.
+
 ## Version 3.6.0
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cap-js/attachments",
   "description": "CAP cds-plugin providing image and attachment storing out-of-the-box.",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "repository": "cap-js/attachments",
   "author": "SAP SE (https://www.sap.com)",
   "homepage": "https://cap.cloud.sap/",


### PR DESCRIPTION
# Release Version 3.6.1

### Changes

This release addresses critical bug fixes in the @cap-js/attachments plugin.

* `CHANGELOG.md`: Added version 3.6.1 release notes documenting two bug fixes
* `package.json`: Bumped version from 3.6.0 to 3.6.1

### Fixed

🐛 **Bug Fixes:**
- Resolved an issue where URLs for nested entities were not generated correctly
- Fixed an internal server error in CDS 8 caused by the absence of `cds.infer?.target`

- [ ] 🔄 Regenerate and Update Summary

