### PR TITLE
Remove lenient handling option for attachment scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,8 +239,6 @@ According to the recommendation of the [Malware Scanning Service](http://help.sa
 
 By default, `scanExpiryMs` is set to `259200000` milliseconds (3 days). Downloading an attachment is not permitted unless its status is `Clean`.
 
-To bypass this restriction, clients may include the header `handling=lenient` in their request, indicating acceptance of the associated risk.
-
 ### Visibility Control for Attachments UI Facet Generation
 
 By setting the `@UI.Hidden` property to `true`, developers can hide the visibility of the plugin in the UI. This feature is particularly useful in scenarios where the visibility of the plugin needs to be dynamically controlled based on certain conditions.

--- a/lib/generic-handlers.js
+++ b/lib/generic-handlers.js
@@ -126,11 +126,6 @@ async function validateAttachment(req) {
     }
     const scanEnabled = cds.env.requires?.attachments?.scan ?? true
 
-    if (req.headers['handling'] === 'lenient') {
-      LOG.warn(`Lenient handling requested for attachment ${req.data.ID || req.params?.at(-1).ID}. Proceeding despite scan status: ${status}`)
-      return
-    }
-
     const scanExpiryMs = cds.env.requires?.attachments?.scanExpiryMs ?? 3 * 24 * 60 * 60 * 1000
     const attachmentId = req.data.ID || req.params?.at(-1).ID
 


### PR DESCRIPTION
# Remove Lenient Handling Option for Attachment Scanning

### Changes

🔒 **Security Enhancement**: Removed the ability to bypass attachment malware scan restrictions using the `handling=lenient` header.

This change enforces stricter security by removing the option for clients to download attachments that have not been scanned or have a non-clean scan status. Previously, clients could include `handling=lenient` in their request headers to bypass scan status checks and download potentially unsafe files.

### Changes

* `lib/generic-handlers.js`: Removed the conditional check that allowed lenient handling via request headers. The code now strictly enforces that attachments must have a `Clean` status before download is permitted, with no bypass option available.
* `README.md`: Removed documentation describing the lenient handling bypass feature, clarifying that downloading attachments is only permitted when their scan status is `Clean`.

- [ ] 🔄 Regenerate and Update Summary

