### PR TITLE
Fix typo

### DIFF
--- a/tests/unit/validateAttachmentSize.test.js
+++ b/tests/unit/validateAttachmentSize.test.js
@@ -1,9 +1,9 @@
 require('../../lib/csn-runtime-extension')
 const cds = require('@sap/cds');
-const path = require("path")
-const app = path.join(__dirname, "../incidents-app")
+const { readFileSync } = cds.utils.fs
+const { join } = cds.utils.path
+const app = join(__dirname, "../incidents-app")
 const { axios, POST } = cds.test(app)
-const fs = require('fs/promises')
 const { validateAttachmentSize } = require('../../lib/generic-handlers');
 const { newIncident } = require('../utils/testUtils');
 
@@ -18,8 +18,8 @@ describe('validateAttachmentSize', () => {
       { headers: { "Content-Type": "application/json" } }
     )
 
-    const fileContent = await fs.readFile(
-      path.join(__dirname, "..", "integration", 'content/sample.pdf')
+    const fileContent = readFileSync(
+      join(__dirname, "..", "integration", 'content/sample.pdf')
     )
 
     const response = await axios.put(


### PR DESCRIPTION
# Refactor: Replace Node.js Built-in Modules with CDS Utils

♻️ **Refactor**: Migrated from Node.js built-in modules (`path`, `fs/promises`) to CDS utility functions for improved consistency with the SAP CAP framework.

### Changes

* `tests/unit/validateAttachmentSize.test.js`: 
  - Replaced `path` module with `cds.utils.path` for path operations
  - Replaced `fs/promises` module with `cds.utils.fs` for file system operations
  - Updated `readFile` to `readFileSync` for synchronous file reading
  - Updated `path.join` to `join` from CDS utilities

### Benefits

✅ Better alignment with SAP CAP best practices  
✅ Consistent API usage across the codebase  
✅ Reduced direct dependency on Node.js built-in modules

- [ ] 🔄 Regenerate and Update Summary

