### PR TITLE
Refactor malwareScanner inheritance and add unit tests

### DIFF
--- a/srv/malwareScanner-mocked.js
+++ b/srv/malwareScanner-mocked.js
@@ -2,97 +2,7 @@ const cds = require("@sap/cds")
 const LOG = cds.log("attachments")
 const crypto = require("crypto")
 
-class MockedMalwareScanner extends cds.ApplicationService {
-  init() {
-    this.on("ScanAttachmentsFile", this.scanAttachmentsFile)
-    this.on("scan", this.scanFile)
-
-    return super.init()
-  }
-
-  /**
-   * Scans the "content" property of the given entity, specified by the CSN name (target) and
-   * the keys object, for malware.
-   * Updates the status property on the given entity to reflect if the file is clean.
-   * Triggers an attachments service delete event to remove the malware.
-   * @param {{data: {target: string, keys: object}}} msg The target is the CSN Entity name, which is used to lookup entity via cds.model.definitions[<target>].
-   */
-  async scanAttachmentsFile(msg) {
-    const { target, keys } = msg.data
-    const scanEnabled = cds.env.requires?.attachments?.scan ?? true
-    if (!scanEnabled) {
-      LOG.warn(`Malware scanner is disabled! Please consider enabling it`)
-      return
-    }
-
-    LOG.debug(
-      `Initiating malware scan request for ${target}, ${JSON.stringify(keys)} `,
-    )
-
-    const AttachmentsSrv = await cds.connect.to("attachments")
-
-    const model = cds.context.model ?? cds.model
-    //Make sure its the active target
-    const _target =
-      model.definitions[target]?.actives ?? model.definitions[target]
-
-    if (!_target) {
-      LOG.error(
-        `Could not scan ${target}, ${JSON.stringify(keys)} for malware as no CSN entity definition was found for the name!`,
-      )
-      return
-    }
-
-    await this.updateStatus(_target, keys, "Scanning")
-
-    LOG.debug(
-      `Fetching file content for scanning for ${target}, ${JSON.stringify(keys)}`,
-    )
-    const contentStream = await AttachmentsSrv.get(
-      model.definitions[target],
-      keys,
-    )
-
-    if (!contentStream) {
-      LOG.warn(
-        `Cannot fetch file content for malware scanning for ${target}, ${JSON.stringify(keys)}! Check if the file exists.`,
-      )
-      await this.updateStatus(_target, keys, "Failed")
-      return
-    }
-
-    let res
-    try {
-      res = await this.scan(contentStream)
-    } catch (err) {
-      LOG.error(
-        `Request to malware scanner failed for ${target}, ${JSON.stringify(keys)}`,
-        err,
-      )
-      await this.updateStatus(target, keys, "Failed")
-      throw err
-    }
-
-    let status = res.isMalware ? "Infected" : "Clean"
-    const hash = res.hash
-
-    if (status === "Infected") {
-      LOG.warn(
-        `Malware scan completed for ${target}, ${keys} - file is infected. Triggering delete of the file.`,
-      )
-      await AttachmentsSrv.emit("DeleteInfectedAttachment", {
-        target: target,
-        keys,
-        hash,
-      })
-    } else {
-      LOG.debug(`Malware scan completed for ${target}, ${keys} - file is clean`)
-    }
-
-    // Assign hash as another condition to ensure the correct file is marked as fine
-    await this.updateStatus(_target, Object.assign({ hash }, keys), status)
-  }
-
+class MockedMalwareScanner extends require("./malwareScanner") {
   /**
    * Mocks scanning the file. Always returns true!
    * @param {import('@sap/cds').Request} the request object
@@ -123,34 +33,6 @@ class MockedMalwareScanner extends cds.ApplicationService {
       mimeType: "empty",
       hash: sha256Hash,
     }
-  }
-
-  async getFileInformation(_target, keys) {
-    const dbResult = await SELECT.one
-      .from(_target.drafts || _target)
-      .columns("mimeType")
-      .where(keys)
-    return dbResult
-  }
-
-  async updateStatus(_target, keys, status) {
-    if (_target.drafts) {
-      await Promise.all([
-        UPDATE.entity(_target)
-          .where(keys)
-          .set({ status, lastScan: new Date() }),
-        UPDATE.entity(_target.drafts)
-          .where(keys)
-          .set({ status, lastScan: new Date() }),
-      ])
-    } else {
-      await UPDATE.entity(_target)
-        .where(keys)
-        .set({ status, lastScan: new Date() })
-    }
-    LOG.info(
-      `Updated scan status to ${status} for ${_target.name}, ${JSON.stringify(keys)}`,
-    )
   }
 }
 

--- a/srv/malwareScanner.js
+++ b/srv/malwareScanner.js
@@ -4,13 +4,127 @@ const https = require("https")
 const { URL } = require("url")
 const LOG = cds.log("attachments")
 
-class MalwareScanner extends require("./malwareScanner-mocked") {
+class MalwareScanner extends cds.ApplicationService {
   get credentials() {
     return getCredentials()
   }
 
   init() {
+    this.on("ScanAttachmentsFile", this.scanAttachmentsFile)
+    this.on("scan", this.scanFile)
+
     return super.init()
+  }
+
+  /**
+   * Scans the "content" property of the given entity, specified by the CSN name (target) and
+   * the keys object, for malware.
+   * Updates the status property on the given entity to reflect if the file is clean.
+   * Triggers an attachments service delete event to remove the malware.
+   * @param {{data: {target: string, keys: object}}} msg The target is the CSN Entity name, which is used to lookup entity via cds.model.definitions[<target>].
+   */
+  async scanAttachmentsFile(msg) {
+    const { target, keys } = msg.data
+    const scanEnabled = cds.env.requires?.attachments?.scan ?? true
+    if (!scanEnabled) {
+      LOG.warn(`Malware scanner is disabled! Please consider enabling it`)
+      return
+    }
+
+    LOG.debug(
+      `Initiating malware scan request for ${target}, ${JSON.stringify(keys)} `,
+    )
+
+    const AttachmentsSrv = await cds.connect.to("attachments")
+
+    const model = cds.context.model ?? cds.model
+    //Make sure its the active target
+    const _target =
+      model.definitions[target]?.actives ?? model.definitions[target]
+
+    if (!_target) {
+      LOG.error(
+        `Could not scan ${target}, ${JSON.stringify(keys)} for malware as no CSN entity definition was found for the name!`,
+      )
+      return
+    }
+
+    await this.updateStatus(_target, keys, "Scanning")
+
+    LOG.debug(
+      `Fetching file content for scanning for ${target}, ${JSON.stringify(keys)}`,
+    )
+    const contentStream = await AttachmentsSrv.get(
+      model.definitions[target],
+      keys,
+    )
+
+    if (!contentStream) {
+      LOG.warn(
+        `Cannot fetch file content for malware scanning for ${target}, ${JSON.stringify(keys)}! Check if the file exists.`,
+      )
+      await this.updateStatus(_target, keys, "Failed")
+      return
+    }
+
+    let res
+    try {
+      res = await this.scan(contentStream)
+    } catch (err) {
+      LOG.error(
+        `Request to malware scanner failed for ${target}, ${JSON.stringify(keys)}`,
+        err,
+      )
+      await this.updateStatus(target, keys, "Failed")
+      throw err
+    }
+
+    let status = res.isMalware ? "Infected" : "Clean"
+    const hash = res.hash
+
+    if (status === "Infected") {
+      LOG.warn(
+        `Malware scan completed for ${target}, ${keys} - file is infected. Triggering delete of the file.`,
+      )
+      await AttachmentsSrv.emit("DeleteInfectedAttachment", {
+        target: target,
+        keys,
+        hash,
+      })
+    } else {
+      LOG.debug(`Malware scan completed for ${target}, ${keys} - file is clean`)
+    }
+
+    // Assign hash as another condition to ensure the correct file is marked as fine
+    await this.updateStatus(_target, Object.assign({ hash }, keys), status)
+  }
+
+  async getFileInformation(_target, keys) {
+    const dbResult = await SELECT.one
+      .from(_target.drafts || _target)
+      .columns("mimeType")
+      .where(keys)
+    return dbResult
+  }
+
+  async updateStatus(_target, keys, status) {
+    if (_target.drafts) {
+      await Promise.all([
+        UPDATE.entity(_target)
+          .where(keys)
+          .set({ status, lastScan: new Date() }),
+        UPDATE.entity(_target.drafts)
+          .where(keys)
+          .set({ status, lastScan: new Date() }),
+      ])
+    } else {
+      await UPDATE.entity(_target)
+        .where(keys)
+        .set({ status, lastScan: new Date() })
+    }
+    LOG.info(
+      `Updated scan status to ${status} for ${_target.name}, ${JSON.stringify(keys)}`,
+    )
   }
 
   /**

--- a/tests/unit/malwareScanner.test.js
+++ b/tests/unit/malwareScanner.test.js
@@ -1,0 +1,227 @@
+require("../../lib/csn-runtime-extension")
+const cds = require("@sap/cds")
+const { join } = cds.utils.path
+cds.test(join(__dirname, "../incidents-app"))
+
+const MalwareScanner = require("../../srv/malwareScanner")
+
+let scanner
+let attachmentsSvc
+
+beforeEach(() => {
+  jest.clearAllMocks()
+
+  cds.env.requires.attachments = { scan: true }
+  cds.env.requires.malwareScanner = {
+    credentials: { uri: "host", certificate: "C", key: "K" },
+  }
+
+  // cds.context is async-local-storage and becomes undefined after await boundaries in tests.
+  // Stub its getter to always return the live model so the scanner can resolve entity definitions.
+  jest.spyOn(cds, "context", "get").mockReturnValue({ model: cds.model })
+
+  attachmentsSvc = {
+    get: jest.fn(),
+    emit: jest.fn().mockResolvedValue(undefined),
+  }
+  cds.connect.to = jest.fn().mockResolvedValue(attachmentsSvc)
+
+  scanner = new MalwareScanner()
+  scanner.scan = jest.fn()
+})
+
+// ---------------------------------------------------------------------------
+// scanAttachmentsFile
+// ---------------------------------------------------------------------------
+
+describe("scanAttachmentsFile", () => {
+  // ProcessorService.Incidents is draft-enabled, so its attachments entity has .drafts
+  const target = "ProcessorService.Incidents.attachments"
+  const keys = { up__ID: cds.utils.uuid(), ID: cds.utils.uuid() }
+
+  it("returns early when scan is disabled", async () => {
+    cds.env.requires.attachments.scan = false
+    await scanner.scanAttachmentsFile({ data: { target, keys } })
+    expect(cds.connect.to).not.toHaveBeenCalled()
+  })
+
+  it("returns early when target is unknown", async () => {
+    await scanner.scanAttachmentsFile({
+      data: { target: "DoesNotExist", keys },
+    })
+    expect(attachmentsSvc.get).not.toHaveBeenCalled()
+  })
+
+  it("sets status Failed when content stream is null", async () => {
+    attachmentsSvc.get.mockResolvedValue(null)
+    jest.spyOn(scanner, "updateStatus").mockResolvedValue()
+    await scanner.scanAttachmentsFile({ data: { target, keys } })
+    expect(scanner.updateStatus).toHaveBeenLastCalledWith(
+      expect.anything(),
+      keys,
+      "Failed",
+    )
+  })
+
+  it("sets status Failed and rethrows when scan throws", async () => {
+    attachmentsSvc.get.mockResolvedValue({})
+    scanner.scan.mockRejectedValue(new Error("boom"))
+    jest.spyOn(scanner, "updateStatus").mockResolvedValue()
+    await expect(
+      scanner.scanAttachmentsFile({ data: { target, keys } }),
+    ).rejects.toThrow("boom")
+    expect(scanner.updateStatus).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "Failed",
+    )
+  })
+
+  it("emits DeleteInfectedAttachment and sets status Infected", async () => {
+    attachmentsSvc.get.mockResolvedValue({})
+    scanner.scan.mockResolvedValue({ isMalware: true, hash: "h1" })
+    jest.spyOn(scanner, "updateStatus").mockResolvedValue()
+    await scanner.scanAttachmentsFile({ data: { target, keys } })
+    expect(attachmentsSvc.emit).toHaveBeenCalledWith(
+      "DeleteInfectedAttachment",
+      expect.objectContaining({ hash: "h1" }),
+    )
+    expect(scanner.updateStatus).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "Infected",
+    )
+  })
+
+  it("does not emit and sets status Clean for clean file", async () => {
+    attachmentsSvc.get.mockResolvedValue({})
+    scanner.scan.mockResolvedValue({ isMalware: false, hash: "h2" })
+    jest.spyOn(scanner, "updateStatus").mockResolvedValue()
+    await scanner.scanAttachmentsFile({ data: { target, keys } })
+    expect(attachmentsSvc.emit).not.toHaveBeenCalled()
+    expect(scanner.updateStatus).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "Clean",
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// updateStatus — insert a real row, call updateStatus, verify DB was changed
+// ---------------------------------------------------------------------------
+
+describe("updateStatus", () => {
+  it("updates status on active table for entity without drafts", async () => {
+    const _target = cds.model.definitions["AdminService.Incidents.attachments"]
+    expect(_target.drafts).toBeFalsy()
+
+    const keys = { up__ID: cds.utils.uuid(), ID: cds.utils.uuid() }
+    await INSERT.into(_target).entries({
+      ...keys,
+      status: "Scanning",
+      filename: "test.pdf",
+    })
+
+    await scanner.updateStatus(_target, keys, "Clean")
+
+    const row = await SELECT.one.from(_target).where(keys)
+    expect(row.status).toBe("Clean")
+    expect(row.lastScan).toBeTruthy()
+  })
+
+  it("updates status on both active and drafts tables for entity with drafts", async () => {
+    const _target =
+      cds.model.definitions["ProcessorService.Incidents.attachments"]
+    expect(_target.drafts).toBeTruthy()
+
+    const keys = { up__ID: cds.utils.uuid(), ID: cds.utils.uuid() }
+    await INSERT.into(_target).entries({
+      ...keys,
+      status: "Scanning",
+      filename: "test.pdf",
+    })
+    await INSERT.into(_target.drafts).entries({
+      ...keys,
+      status: "Scanning",
+      filename: "test.pdf",
+      DraftAdministrativeData_DraftUUID: cds.utils.uuid(),
+    })
+
+    await scanner.updateStatus(_target, keys, "Infected")
+
+    const active = await SELECT.one.from(_target).where(keys)
+    const draft = await SELECT.one.from(_target.drafts).where(keys)
+    expect(active.status).toBe("Infected")
+    expect(draft.status).toBe("Infected")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getFileInformation — uses real SQLite DB (returns undefined for non-existent keys)
+// ---------------------------------------------------------------------------
+
+describe("getFileInformation", () => {
+  it("returns undefined when querying drafts table for non-existent key", async () => {
+    const _target =
+      cds.model.definitions["ProcessorService.Incidents.attachments"]
+    expect(_target.drafts).toBeTruthy()
+    const result = await scanner.getFileInformation(_target, {
+      up__ID: cds.utils.uuid(),
+      ID: cds.utils.uuid(),
+    })
+    expect(result).toBeUndefined()
+  })
+
+  it("returns undefined when querying active table for non-existent key", async () => {
+    const _target = cds.model.definitions["AdminService.Incidents.attachments"]
+    expect(_target.drafts).toBeFalsy()
+    const result = await scanner.getFileInformation(_target, {
+      up__ID: cds.utils.uuid(),
+      ID: cds.utils.uuid(),
+    })
+    expect(result).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getCredentials
+// ---------------------------------------------------------------------------
+
+describe("getCredentials", () => {
+  it("throws when credentials are missing", () => {
+    delete cds.env.requires.malwareScanner
+    expect(() => scanner.credentials).toThrow(
+      "cds.env.requires.malwareScanner.credentials is empty!",
+    )
+  })
+
+  it("returns credentials for valid mTLS", () => {
+    cds.env.requires.malwareScanner = {
+      credentials: { uri: "host", certificate: "C", key: "K" },
+    }
+    expect(scanner.credentials).toMatchObject({
+      uri: "host",
+      certificate: "C",
+      key: "K",
+    })
+  })
+
+  it("returns credentials for valid basic auth", () => {
+    cds.env.requires.malwareScanner = {
+      credentials: { uri: "host", username: "u", password: "p" },
+    }
+    expect(scanner.credentials).toMatchObject({
+      uri: "host",
+      username: "u",
+      password: "p",
+    })
+  })
+
+  it("throws when both mTLS and basic auth are incomplete", () => {
+    cds.env.requires.malwareScanner = { credentials: { uri: "host" } }
+    expect(() => scanner.credentials).toThrow(
+      "Missing Malware Scanner credentials:",
+    )
+  })
+})


### PR DESCRIPTION
`MockedMalwareScanner` and `MalwareScanner` previously shared duplicated orchestration logic (`scanAttachmentsFile`, `updateStatus`,
`getFileInformation`) because the inheritance was inverted: `MalwareScanner` extended `MockedMalwareScanner`.

This PR fixes the inheritance direction and adds unit tests to cover the now-canonical base class.

### Changes

**`srv/malwareScanner.js`**:  promoted to the true base class

- Now extends `cds.ApplicationService` directly
- All shared orchestration logic moved here from `malwareScanner-mocked.js` - no logical changes 

**`srv/malwareScanner-mocked.js`**: simplified to a thin subclass

- Now extends `MalwareScanner` instead of duplicating its logic
- Only overrides `scanFile` with the mock implementation

**`tests/unit/malwareScanner.test.js`**: new unit test file

- Uses `cds.test()` (same pattern as`validateAttachmentSize.test.js`)
- Only mocks truly external dependencies: `cds.connect.to` (attachments service) and `scanner.scan` (BTP HTTP call)
- 14 test cases covering all branches of `scanAttachmentsFile`, `updateStatus`, `getFileInformation`, and `getCredentials`
- `updateStatus` tests insert rows and verify the DB state after the call
