### PR TITLE
Fix/bypass draft does not cause attachment deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
+- When `cds.env.fiori.bypass_draft` was enabled attachments were wrongfully deleted
+
 ## Version 3.10.0
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "node": ">=18.0.0"
   },
   "cds": {
+    "fiori": {
+      "bypass_draft": true
+    },
     "requires": {
       "malwareScanner": {
         "vcap": {

--- a/srv/basic.js
+++ b/srv/basic.js
@@ -417,7 +417,7 @@ class AttachmentsService extends cds.Service {
       // If no draft exists at all, this means it is the bypass draft option where
       // active entities can be modified
       if (!draft) {
-        draft = active;
+        draft = active
       }
 
       if (!active) return

--- a/srv/basic.js
+++ b/srv/basic.js
@@ -417,7 +417,8 @@ class AttachmentsService extends cds.Service {
       // If no draft exists at all, this means it is the bypass draft option where
       // active entities can be modified
       if (!draft) {
-        draft = active
+        DEBUG?.(`Skipping attachDeletionData handler detecting deleted attachments because no draft was found for ${req.target.name} and the where condition: `, whereCond);
+        return;
       }
 
       if (!active) return

--- a/srv/basic.js
+++ b/srv/basic.js
@@ -410,7 +410,7 @@ class AttachmentsService extends cds.Service {
         }
       }
 
-      let [draft, active] = await Promise.all([
+      const [draft, active] = await Promise.all([
         SELECT.one.from(req.target.drafts).where(whereCond).columns(columns),
         SELECT.one.from(req.target).where(whereCond).columns(columns),
       ])

--- a/srv/basic.js
+++ b/srv/basic.js
@@ -417,8 +417,11 @@ class AttachmentsService extends cds.Service {
       // If no draft exists at all, this means it is the bypass draft option where
       // active entities can be modified
       if (!draft) {
-        DEBUG?.(`Skipping attachDeletionData handler detecting deleted attachments because no draft was found for ${req.target.name} and the where condition: `, whereCond);
-        return;
+        DEBUG?.(
+          `Skipping attachDeletionData handler detecting deleted attachments because no draft was found for ${req.target.name} and the where condition: `,
+          whereCond,
+        )
+        return
       }
 
       if (!active) return

--- a/srv/basic.js
+++ b/srv/basic.js
@@ -410,10 +410,15 @@ class AttachmentsService extends cds.Service {
         }
       }
 
-      const [draft, active] = await Promise.all([
+      let [draft, active] = await Promise.all([
         SELECT.one.from(req.target.drafts).where(whereCond).columns(columns),
         SELECT.one.from(req.target).where(whereCond).columns(columns),
       ])
+      // If no draft exists at all, this means it is the bypass draft option where
+      // active entities can be modified
+      if (!draft) {
+        draft = active;
+      }
 
       if (!active) return
 

--- a/tests/integration/attachments.test.js
+++ b/tests/integration/attachments.test.js
@@ -1861,7 +1861,7 @@ describe("Tests for uploading/deleting attachments through API calls", () => {
         true,
       )
     }
-    
+
     // Second scan round needed due to scan expiry limit for other tests. Triggered via rescan
     await GET(
       `odata/v4/processor/Incidents(ID=${incidentID},IsActiveEntity=true)/attachments(up__ID=${incidentID},ID=${sampleDocID},IsActiveEntity=true)/content`,

--- a/tests/integration/attachments.test.js
+++ b/tests/integration/attachments.test.js
@@ -1817,6 +1817,61 @@ describe("Tests for uploading/deleting attachments through API calls", () => {
     expect(response.data.ID).toBeTruthy()
     expect(response.data.status).toBeDefined()
   })
+
+  it("Updating parent should not cause attachment deletes", async () => {
+    const incidentID = await newIncident(POST, "processor")
+    let sampleDocID
+    const scanCleanWaiter = waitForScanStatus("Clean")
+    // Upload attachment using helper function
+    sampleDocID = await uploadDraftAttachment(utils, POST, GET, incidentID)
+    expect(sampleDocID).toBeTruthy()
+
+    //read attachments list for Incident
+    const attachmentResponse = await GET(
+      `odata/v4/processor/Incidents(ID=${incidentID},IsActiveEntity=true)/attachments`,
+    )
+    //the data should have only one attachment
+    expect(attachmentResponse.status).toEqual(200)
+    expect(attachmentResponse.data.value.length).toEqual(1)
+    sampleDocID = attachmentResponse.data.value[0].ID
+
+    await scanCleanWaiter
+
+    const contentResponse = await GET(
+      `odata/v4/processor/Incidents(ID=${incidentID},IsActiveEntity=true)/attachments(up__ID=${incidentID},ID=${sampleDocID},IsActiveEntity=true)/content`,
+    )
+    expect(contentResponse.status).toEqual(200)
+    expect(contentResponse.data).toBeTruthy()
+
+    const resultResponse = await PATCH(
+      `odata/v4/processor/Incidents(ID=${incidentID},IsActiveEntity=true)`,
+      {
+        status_code: 'N'
+      }
+    )
+    expect(resultResponse.status).toEqual(200)
+
+    try {
+      await waitForDeletion(sampleDocID)
+      // Should throw due to timeout
+      expect(true).toEqual(false);
+    } catch(error) {
+      expect(error.message.startsWith('Timeout waiting for deletion')).toEqual(true);
+    }
+
+
+    // Second round needed due to scan expiry limit for other tests
+    const scanCleanWaiter2 = waitForScanStatus("Clean")
+    await GET(
+      `odata/v4/processor/Incidents(ID=${incidentID},IsActiveEntity=true)/attachments(up__ID=${incidentID},ID=${sampleDocID},IsActiveEntity=true)/content`,
+    )
+    await scanCleanWaiter2
+    const contentAfterActiveUpdate = await GET(
+      `odata/v4/processor/Incidents(ID=${incidentID},IsActiveEntity=true)/attachments(up__ID=${incidentID},ID=${sampleDocID},IsActiveEntity=true)/content`,
+    )
+    expect(contentAfterActiveUpdate.status).toEqual(200)
+    expect(contentAfterActiveUpdate.data).toBeTruthy()
+  })
 })
 
 describe("Tests for attachments facet disable", () => {

--- a/tests/integration/attachments.test.js
+++ b/tests/integration/attachments.test.js
@@ -1851,7 +1851,6 @@ describe("Tests for uploading/deleting attachments through API calls", () => {
     )
     expect(resultResponse.status).toEqual(200)
 
-    // Second round needed due to scan expiry limit for other tests
     const scanCleanWaiter2 = waitForScanStatus("Clean")
     try {
       await waitForDeletion(attachmentResponse.data.value[0].url)
@@ -1862,7 +1861,8 @@ describe("Tests for uploading/deleting attachments through API calls", () => {
         true,
       )
     }
-
+    
+    // Second scan round needed due to scan expiry limit for other tests. Triggered via rescan
     await GET(
       `odata/v4/processor/Incidents(ID=${incidentID},IsActiveEntity=true)/attachments(up__ID=${incidentID},ID=${sampleDocID},IsActiveEntity=true)/content`,
     )

--- a/tests/integration/attachments.test.js
+++ b/tests/integration/attachments.test.js
@@ -1846,19 +1846,20 @@ describe("Tests for uploading/deleting attachments through API calls", () => {
     const resultResponse = await PATCH(
       `odata/v4/processor/Incidents(ID=${incidentID},IsActiveEntity=true)`,
       {
-        status_code: 'N'
-      }
+        status_code: "N",
+      },
     )
     expect(resultResponse.status).toEqual(200)
 
     try {
       await waitForDeletion(sampleDocID)
       // Should throw due to timeout
-      expect(true).toEqual(false);
-    } catch(error) {
-      expect(error.message.startsWith('Timeout waiting for deletion')).toEqual(true);
+      expect(true).toEqual(false)
+    } catch (error) {
+      expect(error.message.startsWith("Timeout waiting for deletion")).toEqual(
+        true,
+      )
     }
-
 
     // Second round needed due to scan expiry limit for other tests
     const scanCleanWaiter2 = waitForScanStatus("Clean")

--- a/tests/integration/attachments.test.js
+++ b/tests/integration/attachments.test.js
@@ -1851,6 +1851,8 @@ describe("Tests for uploading/deleting attachments through API calls", () => {
     )
     expect(resultResponse.status).toEqual(200)
 
+    // Second round needed due to scan expiry limit for other tests
+    const scanCleanWaiter2 = waitForScanStatus("Clean")
     try {
       await waitForDeletion(attachmentResponse.data.value[0].url)
       // Should throw due to timeout
@@ -1861,8 +1863,6 @@ describe("Tests for uploading/deleting attachments through API calls", () => {
       )
     }
 
-    // Second round needed due to scan expiry limit for other tests
-    const scanCleanWaiter2 = waitForScanStatus("Clean")
     await GET(
       `odata/v4/processor/Incidents(ID=${incidentID},IsActiveEntity=true)/attachments(up__ID=${incidentID},ID=${sampleDocID},IsActiveEntity=true)/content`,
     )

--- a/tests/integration/attachments.test.js
+++ b/tests/integration/attachments.test.js
@@ -1852,7 +1852,7 @@ describe("Tests for uploading/deleting attachments through API calls", () => {
     expect(resultResponse.status).toEqual(200)
 
     try {
-      await waitForDeletion(sampleDocID)
+      await waitForDeletion(attachmentResponse.data.value[0].url)
       // Should throw due to timeout
       expect(true).toEqual(false)
     } catch (error) {


### PR DESCRIPTION
When fire.bypass_draft was enabled no draft, in the UPDATE handler detecting draft changes, was returned causing the deletion logic to delete all active attachments.