### PR TITLE
Fix wrong attachment size validation error message arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 3.12.0 - Upcoming
+
+### Fixed
+
+- Wrong file name being shown when rejecting an attachment due to file size.
+
 ## Version 3.11.0
 
 ### Added

--- a/lib/generic-handlers.js
+++ b/lib/generic-handlers.js
@@ -271,7 +271,7 @@ async function validateAttachmentSize(req, validateContentLength = false) {
 
     const attachmentRef = await SELECT.one("filename")
       .from(req.target)
-      .where({ up__ID: req.data.up__ID })
+      .where({ ID: req.data.ID })
     const ipAddress = req.req?.socket?.remoteAddress
     cds.spawn(async () => {
       try {

--- a/tests/unit/validateAttachmentSize.test.js
+++ b/tests/unit/validateAttachmentSize.test.js
@@ -48,4 +48,52 @@ describe("validateAttachmentSize", () => {
     validateAttachmentSize(req)
     expect(req.reject).not.toHaveBeenCalled()
   })
+
+  it("should SELECT the correct attachment by ID, not a random one from the parent", async () => {
+    const target =
+      cds.model.definitions["AdminService.Incidents.maximumSizeAttachments"]
+    const parentID = cds.utils.uuid()
+    const targetID = cds.utils.uuid()
+
+    // Insert many decoys under the same parent so a wrong SELECT
+    // (e.g. missing WHERE or wrong key) is very likely to return a decoy
+    const decoys = Array.from({ length: 10 }, (_, i) => ({
+      up__ID: parentID,
+      ID: cds.utils.uuid(),
+      filename: `decoy-${i + 1}.pdf`,
+      status: "Scanning",
+    }))
+
+    await INSERT.into(target).entries([
+      ...decoys.slice(0, 5),
+      {
+        up__ID: parentID,
+        ID: targetID,
+        filename: "target-file.pdf",
+        status: "Scanning",
+      },
+      ...decoys.slice(5),
+    ])
+
+    const req = {
+      target,
+      data: {
+        content: { pause: jest.fn() },
+        up__ID: parentID,
+        ID: targetID,
+      },
+      headers: { "content-length": "999999999999" },
+      reject: jest.fn(),
+    }
+
+    await validateAttachmentSize(req)
+
+    expect(req.reject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 413,
+        message: "AttachmentSizeExceeded",
+        args: ["target-file.pdf", "5MB"],
+      }),
+    )
+  })
 })


### PR DESCRIPTION
The select was choosing a random attachment from the parent instead of the actual attachment.