### PR TITLE
Rescan when status is unscanned

### DIFF
--- a/_i18n/messages.properties
+++ b/_i18n/messages.properties
@@ -6,4 +6,4 @@ InvalidContentLengthHeader=The 'Content-Length' header value '{contentLength}' i
 AttachmentAlreadyExistsCannotBeOverwritten=Attachment {0} already exists and cannot be overwritten.
 MaximumAmountExceeded=Cannot upload more than {0} attachments!
 MinimumAmountNotFulfilled=At least {0} attachments must be uploaded!
-UnableToDownloadAttachmentScanStatusExpired=The previous scan was more than 3 days ago, please wait for the attachment to be rescanned.
+UnableToDownloadAttachmentScanStatusExpired=The previous scan was more than 3 days ago, please try to download again in a moment, after the attachment was rescanned.

--- a/lib/generic-handlers.js
+++ b/lib/generic-handlers.js
@@ -146,7 +146,7 @@ async function validateAttachment(req) {
     const attachmentId = req.data.ID || req.params?.at(-1).ID
 
     if (scanEnabled) {
-      if (status === 'Unscanned') {
+      if (status === "Unscanned") {
         rescan(req, attachmentId)
       } else if (status !== "Clean") {
         const ipAddress = req.req?.socket?.remoteAddress
@@ -189,8 +189,7 @@ async function rescan(req, attachmentId) {
 
   // Set status to Scanning and commit before emitting event to prevent race conditions
   cds.tx(
-    async () =>
-      await malwareScanner.updateStatus(target, keys, "Scanning"),
+    async () => await malwareScanner.updateStatus(target, keys, "Scanning"),
   )
 
   // Trigger scanning in separate transaction as req.reject closes the current transaction
@@ -245,9 +244,9 @@ async function validateAttachmentSize(req, validateContentLength = false) {
 
   const maxFileSize = req.target.elements["content"]["@Validation.Maximum"]
     ? (sizeInBytes(
-      req.target.elements["content"]["@Validation.Maximum"],
-      req.target.name,
-    ) ?? MAX_FILE_SIZE)
+        req.target.elements["content"]["@Validation.Maximum"],
+        req.target.name,
+      ) ?? MAX_FILE_SIZE)
     : MAX_FILE_SIZE
 
   if (!validateContentLength) {

--- a/lib/generic-handlers.js
+++ b/lib/generic-handlers.js
@@ -147,7 +147,7 @@ async function validateAttachment(req) {
 
     if (scanEnabled) {
       if (status === "Unscanned") {
-        rescan(req, attachmentId)
+        return rescan(req, attachmentId)
       } else if (status !== "Clean") {
         const ipAddress = req.req?.socket?.remoteAddress
         cds.spawn(async () => {
@@ -170,7 +170,7 @@ async function validateAttachment(req) {
         scanExpiryMs !== -1 &&
         (!lastScan || Date.now() - new Date(lastScan).getTime() > scanExpiryMs)
       ) {
-        rescan(req, attachmentId)
+        return rescan(req, attachmentId)
       }
     }
   }

--- a/lib/generic-handlers.js
+++ b/lib/generic-handlers.js
@@ -146,7 +146,9 @@ async function validateAttachment(req) {
     const attachmentId = req.data.ID || req.params?.at(-1).ID
 
     if (scanEnabled) {
-      if (status !== "Clean") {
+      if (status === 'Unscanned') {
+        rescan(req, attachmentId)
+      } else if (status !== "Clean") {
         const ipAddress = req.req?.socket?.remoteAddress
         cds.spawn(async () => {
           try {
@@ -168,38 +170,42 @@ async function validateAttachment(req) {
         scanExpiryMs !== -1 &&
         (!lastScan || Date.now() - new Date(lastScan).getTime() > scanExpiryMs)
       ) {
-        LOG.debug(
-          `Attachment ${attachmentId} scan has expired or no lastScan date. Triggering re-scan.`,
-        )
-
-        const target = req.target.name,
-          keys = { ID: attachmentId }
-
-        // No scan or scan expired: trigger scan and reject
-        const malwareScanner = await cds.connect.to("malwareScanner")
-
-        // Set status to Scanning and commit before emitting event to prevent race conditions
-        cds.tx(
-          async () =>
-            await malwareScanner.updateStatus(target, keys, "Scanning"),
-        )
-
-        // Trigger scanning in separate transaction as req.reject closes the current transaction
-        cds.spawn(async () => {
-          await malwareScanner.emit("ScanAttachmentsFile", {
-            target,
-            keys,
-          })
-        })
-
-        // req.reject does not accept status codes below 400, so we throw the error directly
-        throw cds.error({
-          status: 202,
-          code: "UnableToDownloadAttachmentScanStatusExpired",
-        })
+        rescan(req, attachmentId)
       }
     }
   }
+}
+
+async function rescan(req, attachmentId) {
+  LOG.debug(
+    `Attachment ${attachmentId} scan has expired or no lastScan date. Triggering re-scan.`,
+  )
+
+  const target = req.target.name,
+    keys = { ID: attachmentId }
+
+  // No scan or scan expired: trigger scan and reject
+  const malwareScanner = await cds.connect.to("malwareScanner")
+
+  // Set status to Scanning and commit before emitting event to prevent race conditions
+  cds.tx(
+    async () =>
+      await malwareScanner.updateStatus(target, keys, "Scanning"),
+  )
+
+  // Trigger scanning in separate transaction as req.reject closes the current transaction
+  cds.spawn(async () => {
+    await malwareScanner.emit("ScanAttachmentsFile", {
+      target,
+      keys,
+    })
+  })
+
+  // req.reject does not accept status codes below 400, so we throw the error directly
+  throw cds.error({
+    status: 202,
+    code: "UnableToDownloadAttachmentScanStatusExpired",
+  })
 }
 
 /**
@@ -239,9 +245,9 @@ async function validateAttachmentSize(req, validateContentLength = false) {
 
   const maxFileSize = req.target.elements["content"]["@Validation.Maximum"]
     ? (sizeInBytes(
-        req.target.elements["content"]["@Validation.Maximum"],
-        req.target.name,
-      ) ?? MAX_FILE_SIZE)
+      req.target.elements["content"]["@Validation.Maximum"],
+      req.target.name,
+    ) ?? MAX_FILE_SIZE)
     : MAX_FILE_SIZE
 
   if (!validateContentLength) {

--- a/tests/integration/attachments.test.js
+++ b/tests/integration/attachments.test.js
@@ -275,7 +275,7 @@ describe("Tests for uploading/deleting attachments through API calls", () => {
     ).catch((e) => {
       expect(e.status).toEqual(202)
       expect(e.response.data.error.message).toContain(
-        "The last scan is older than 3 days. Please wait while the attachment is being re-scanned.",
+        "The previous scan was more than 3 days ago, please try to download again in a moment, after the attachment was rescanned.",
       )
     })
   })

--- a/tests/unit/rejectionEvents.test.js
+++ b/tests/unit/rejectionEvents.test.js
@@ -10,9 +10,11 @@ const {
 } = require("../../lib/generic-handlers")
 
 let attachmentsSvc
+let malwareScannerSvc
 let originalConnectTo
 let spawnCallback
 let originalSpawn
+let originalTx
 
 beforeEach(() => {
   jest.restoreAllMocks()
@@ -21,9 +23,14 @@ beforeEach(() => {
     emit: jest.fn().mockResolvedValue(undefined),
     getStatus: jest.fn(),
   }
+  malwareScannerSvc = {
+    updateStatus: jest.fn().mockResolvedValue(undefined),
+    emit: jest.fn().mockResolvedValue(undefined),
+  }
   originalConnectTo = cds.connect.to
   cds.connect.to = jest.fn().mockImplementation((name) => {
     if (name === "attachments") return Promise.resolve(attachmentsSvc)
+    if (name === "malwareScanner") return Promise.resolve(malwareScannerSvc)
     return originalConnectTo.call(cds.connect, name)
   })
 
@@ -33,11 +40,15 @@ beforeEach(() => {
     spawnCallback = fn
     return { on: jest.fn() }
   })
+
+  originalTx = cds.tx
+  cds.tx = jest.fn().mockImplementation(async (fn) => await fn())
 })
 
 afterEach(() => {
   cds.connect.to = originalConnectTo
   cds.spawn = originalSpawn
+  cds.tx = originalTx
 })
 
 describe("AttachmentUploadRejected event", () => {
@@ -454,5 +465,71 @@ describe("AttachmentDownloadRejected event", () => {
       "AttachmentDownloadRejected",
       expect.anything(),
     )
+  })
+})
+
+describe("Rescan triggered for Unscanned attachment", () => {
+  it("should trigger rescan when status is Unscanned", async () => {
+    const target = cds.model.definitions["AdminService.Incidents.attachments"]
+
+    attachmentsSvc.getStatus = jest.fn().mockResolvedValue({
+      status: "Unscanned",
+      lastScan: null,
+    })
+
+    const attachmentId = cds.utils.uuid()
+    const req = {
+      target,
+      data: { ID: attachmentId },
+      req: { url: "/some/path/content" },
+      query: { SELECT: { columns: [] } },
+      params: [{ ID: attachmentId }],
+      reject: jest.fn(),
+    }
+
+    cds.env.requires.attachments = { scan: true }
+
+    // rescan() is fire-and-forget (not awaited) inside validateAttachment.
+    // It awaits cds.connect.to("malwareScanner"), then calls cds.tx, cds.spawn,
+    // and throws a 202 error. To avoid unhandled rejection crashing Jest,
+    // return a never-resolving promise for "malwareScanner" — rescan will hang
+    // at the first await, proving it was triggered without producing a rejection.
+    cds.connect.to = jest.fn().mockImplementation((name) => {
+      if (name === "attachments") return Promise.resolve(attachmentsSvc)
+      if (name === "malwareScanner") return new Promise(() => {}) // never resolves
+      return originalConnectTo.call(cds.connect, name)
+    })
+
+    await require("../../lib/generic-handlers").validateAttachment(req)
+
+    // Verify rescan was triggered: it connected to malwareScanner
+    expect(cds.connect.to).toHaveBeenCalledWith("malwareScanner")
+  })
+
+  it("should not trigger rescan when scan is disabled", async () => {
+    const target = cds.model.definitions["AdminService.Incidents.attachments"]
+
+    attachmentsSvc.getStatus = jest.fn().mockResolvedValue({
+      status: "Unscanned",
+      lastScan: null,
+    })
+
+    const attachmentId = cds.utils.uuid()
+    const req = {
+      target,
+      data: { ID: attachmentId },
+      req: { url: "/some/path/content" },
+      query: { SELECT: { columns: [] } },
+      params: [{ ID: attachmentId }],
+      reject: jest.fn(),
+    }
+
+    cds.env.requires.attachments = { scan: false }
+
+    await require("../../lib/generic-handlers").validateAttachment(req)
+
+    expect(malwareScannerSvc.updateStatus).not.toHaveBeenCalled()
+    expect(cds.spawn).not.toHaveBeenCalled()
+    expect(req.reject).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/rejectionEvents.test.js
+++ b/tests/unit/rejectionEvents.test.js
@@ -489,18 +489,14 @@ describe("Rescan triggered for Unscanned attachment", () => {
 
     cds.env.requires.attachments = { scan: true }
 
-    // rescan() is fire-and-forget (not awaited) inside validateAttachment.
-    // It awaits cds.connect.to("malwareScanner"), then calls cds.tx, cds.spawn,
-    // and throws a 202 error. To avoid unhandled rejection crashing Jest,
-    // return a never-resolving promise for "malwareScanner" — rescan will hang
-    // at the first await, proving it was triggered without producing a rejection.
-    cds.connect.to = jest.fn().mockImplementation((name) => {
-      if (name === "attachments") return Promise.resolve(attachmentsSvc)
-      if (name === "malwareScanner") return new Promise(() => {}) // never resolves
-      return originalConnectTo.call(cds.connect, name)
+    // rescan() is now awaited inside validateAttachment, so it will throw
+    // a 202 error. Verify it connects to malwareScanner and throws.
+    await expect(
+      require("../../lib/generic-handlers").validateAttachment(req),
+    ).rejects.toMatchObject({
+      status: 202,
+      code: "UnableToDownloadAttachmentScanStatusExpired",
     })
-
-    await require("../../lib/generic-handlers").validateAttachment(req)
 
     // Verify rescan was triggered: it connected to malwareScanner
     expect(cds.connect.to).toHaveBeenCalledWith("malwareScanner")


### PR DESCRIPTION
Rescan when status is unscanned and improve the error message to make it clear that the user needs to press download again after a few seconds when the rescan is triggered.