### PR TITLE
Delete duplicate scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 3.13.0
+
+### Fixed
+
+- Await function setting status to scanning to avoid race conditions.
+
 ## Version 3.12.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- Await function setting status to scanning to avoid race conditions.
+- Remove extra function setting status to scanning to avoid race conditions.
 
 ## Version 3.12.1
 

--- a/lib/generic-handlers.js
+++ b/lib/generic-handlers.js
@@ -189,12 +189,6 @@ async function rescan(req, attachmentId) {
   // No scan or scan expired: trigger scan and reject
   const malwareScanner = await cds.connect.to("malwareScanner")
 
-  // Set status to Scanning and commit before emitting event to prevent race conditions
-  cds.tx(
-    async () => await malwareScanner.updateStatus(target, keys, "Scanning"),
-  )
-
-  // Trigger scanning in separate transaction as req.reject closes the current transaction
   cds.spawn(async () => {
     await malwareScanner.emit("ScanAttachmentsFile", {
       target,

--- a/lib/generic-handlers.js
+++ b/lib/generic-handlers.js
@@ -190,7 +190,7 @@ async function rescan(req, attachmentId) {
   const malwareScanner = await cds.connect.to("malwareScanner")
 
   // Set status to Scanning and commit before emitting event to prevent race conditions
-  await cds.tx(
+  cds.tx(
     async () => await malwareScanner.updateStatus(target, keys, "Scanning"),
   )
 

--- a/lib/generic-handlers.js
+++ b/lib/generic-handlers.js
@@ -190,7 +190,7 @@ async function rescan(req, attachmentId) {
   const malwareScanner = await cds.connect.to("malwareScanner")
 
   // Set status to Scanning and commit before emitting event to prevent race conditions
-  cds.tx(
+  await cds.tx(
     async () => await malwareScanner.updateStatus(target, keys, "Scanning"),
   )
 


### PR DESCRIPTION
Await setting the scan status to 'scanning' to avoid race condition.

For issue #432