### PR TITLE
Fix: Querying for content column from Object Storage should work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 3.12.2
+
+### Fixed
+
+- Querying from content column while using object storage now returns expected result.
+
 ## Version 3.12.1
 
 ### Added

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -69,26 +69,38 @@ cds.once("served", () => {
       )
         return next()
 
-      const contentIdx = columns.findIndex((c) => c?.ref?.[0] === "content")
-      if (contentIdx === -1) return next()
+      const hasContentColumn = columns.some((c) => c?.ref?.[0] === "content")
+      if (!hasContentColumn) return next()
 
-      const idWasAdded = !columns.some((c) => c?.ref?.[0] === "ID")
-      if (idWasAdded) columns.push({ ref: ["ID"] })
+      const idMissingFromColumns = !columns.some((c) => c?.ref?.[0] === "ID")
+      if (idMissingFromColumns)
+        req.query.SELECT.columns = [...columns, { ref: ["ID"] }]
 
-      const results = await next()
-      if (!results) return results
-
-      const AttachmentsSrv = await cds.connect.to("attachments")
-      const items = Array.isArray(results) ? results : [results]
-
-      for (const attachment of items) {
-        if (attachment?.ID && !attachment.content) {
-          attachment.content = await AttachmentsSrv.get(req.target, {
-            ID: attachment.ID,
-          })
-        }
-        if (idWasAdded && attachment) delete attachment.ID
+      let results
+      try {
+        results = await next()
+      } finally {
+        if (idMissingFromColumns) req.query.SELECT.columns = columns
       }
+
+      if (!results || results.length === 0) return results
+
+      const items = Array.isArray(results) ? results : [results]
+      const needsFetch = items.some((a) => a?.ID && !a.content)
+      const AttachmentsSrv = needsFetch
+        ? await cds.connect.to("attachments")
+        : null
+
+      await Promise.all(
+        items.map(async (attachment) => {
+          if (attachment?.ID && !attachment.content) {
+            attachment.content = await AttachmentsSrv.get(req.target, {
+              ID: attachment.ID,
+            })
+          }
+          if (idMissingFromColumns && attachment) delete attachment.ID
+        }),
+      )
 
       return results
     })

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -60,6 +60,35 @@ cds.once("served", () => {
       // Return the data as the result (attachment.put handles the actual storage)
       return entries.length === 1 ? entries[0] : entries
     })
+    db.on("SELECT", async function handleDBSelectForContent(req, next) {
+      const columns = req.query?.SELECT?.columns
+      if (
+        !Array.isArray(columns) ||
+        !req.target?._attachments?.isAttachmentsEntity ||
+        getAttachmentKind() === "db"
+      ) return next()
+
+      const contentIdx = columns.findIndex((c) => c?.ref?.[0] === "content")
+      if (contentIdx === -1) return next()
+
+      const idWasAdded = !columns.some((c) => c?.ref?.[0] === "ID")
+      if (idWasAdded) columns.push({ ref: ["ID"] })
+
+      const results = await next()
+      if (!results) return results
+
+      const AttachmentsSrv = await cds.connect.to("attachments")
+      const items = Array.isArray(results) ? results : [results]
+
+      for (const attachment of items) {
+        if (attachment?.ID && !attachment.content) {
+          attachment.content = await AttachmentsSrv.get(req.target, { ID: attachment.ID })
+        }
+        if (idWasAdded && attachment) delete attachment.ID
+      }
+
+      return results
+    })
   })
 })
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -83,9 +83,10 @@ cds.once("served", () => {
         if (idMissingFromColumns) req.query.SELECT.columns = columns
       }
 
-      if (!results || results.length === 0) return results
+      if (!results) return results
 
       const items = Array.isArray(results) ? results : [results]
+      if (items.length === 0) return results
       const needsFetch = items.some((a) => a?.ID && !a.content)
       const AttachmentsSrv = needsFetch
         ? await cds.connect.to("attachments")
@@ -94,9 +95,11 @@ cds.once("served", () => {
       await Promise.all(
         items.map(async (attachment) => {
           if (attachment?.ID && !attachment.content) {
-            attachment.content = await AttachmentsSrv.get(req.target, {
-              ID: attachment.ID,
-            })
+            try {
+              attachment.content = await AttachmentsSrv.get(req.target, { ID: attachment.ID })
+            } catch (err) {
+              LOG.error("Failed to fetch content from object storage", { ID: attachment.ID, err })
+            }
           }
           if (idMissingFromColumns && attachment) delete attachment.ID
         }),

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -66,7 +66,8 @@ cds.once("served", () => {
         !Array.isArray(columns) ||
         !req.target?._attachments?.isAttachmentsEntity ||
         getAttachmentKind() === "db"
-      ) return next()
+      )
+        return next()
 
       const contentIdx = columns.findIndex((c) => c?.ref?.[0] === "content")
       if (contentIdx === -1) return next()
@@ -82,7 +83,9 @@ cds.once("served", () => {
 
       for (const attachment of items) {
         if (attachment?.ID && !attachment.content) {
-          attachment.content = await AttachmentsSrv.get(req.target, { ID: attachment.ID })
+          attachment.content = await AttachmentsSrv.get(req.target, {
+            ID: attachment.ID,
+          })
         }
         if (idWasAdded && attachment) delete attachment.ID
       }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -96,9 +96,14 @@ cds.once("served", () => {
         items.map(async (attachment) => {
           if (attachment?.ID && !attachment.content) {
             try {
-              attachment.content = await AttachmentsSrv.get(req.target, { ID: attachment.ID })
+              attachment.content = await AttachmentsSrv.get(req.target, {
+                ID: attachment.ID,
+              })
             } catch (err) {
-              LOG.error("Failed to fetch content from object storage", { ID: attachment.ID, err })
+              LOG.error("Failed to fetch content from object storage", {
+                ID: attachment.ID,
+                err,
+              })
             }
           }
           if (idMissingFromColumns && attachment) delete attachment.ID

--- a/tests/integration/attachments.test.js
+++ b/tests/integration/attachments.test.js
@@ -1886,6 +1886,28 @@ describe("Tests for uploading/deleting attachments through API calls", () => {
     expect(contentAfterActiveUpdate.status).toEqual(200)
     expect(contentAfterActiveUpdate.data).toBeTruthy()
   })
+
+  // prettier-ignore
+  isNotLocal("Programmatic SELECT with columns('content') returns bytes from object store", async () => {
+    const incidentID = await newIncident(POST, "processor")
+    const scanCleanWaiter = waitForScanStatus("Clean")
+
+    await uploadDraftAttachment(utils, POST, GET, incidentID)
+    await scanCleanWaiter
+
+    const srv = await cds.connect.to("ProcessorService")
+    const Attachments = srv.entities["Incidents.attachments"]
+
+    const result = await runWithUser(alice, () =>
+      SELECT.one
+        .from(Attachments)
+        .columns("content")
+        .where({ up__ID: incidentID }),
+    )
+
+    expect(result).toBeTruthy()
+    expect(result.content).toBeTruthy()
+  })
 })
 
 describe("Tests for attachments facet disable", () => {

--- a/tests/integration/attachments.test.js
+++ b/tests/integration/attachments.test.js
@@ -1906,7 +1906,13 @@ describe("Tests for uploading/deleting attachments through API calls", () => {
     )
 
     expect(result).toBeTruthy()
-    expect(result.content).toBeTruthy()
+    const chunks = []
+    await new Promise((resolve, reject) => {
+      result.content.on("data", (chunk) => chunks.push(chunk))
+      result.content.on("end", resolve)
+      result.content.on("error", reject)
+    })
+    expect(Buffer.concat(chunks).length).toBeGreaterThan(0)
   })
 })
 


### PR DESCRIPTION
Select content data from object storage if not found in HANA. HANA uses a reference but a direct query, stated as possible in the readme, does not get this reference and returns null. This PR intercepts such a query request and selects the content from object storage and returns it.

Addresses issue #447 