### PR TITLE
test: decouple deletion test from outbox internals

### DIFF
--- a/tests/integration/attachments.test.js
+++ b/tests/integration/attachments.test.js
@@ -379,6 +379,8 @@ describe("Tests for uploading/deleting attachments through API calls", () => {
       attachmentIDs.push(req.data?.url)
     })
 
+    const deletionWaiter = waitForDeletion(attachmentData.data.url)
+
     //delete attachment
     await DELETE(
       `odata/v4/processor/Incidents_attachments(up__ID=${incidentID},ID=${sampleDocID},IsActiveEntity=false)`,
@@ -392,7 +394,7 @@ describe("Tests for uploading/deleting attachments through API calls", () => {
     )
 
     // Wait for the outbox to dispatch the DeleteAttachment event
-    await waitForDeletion(attachmentData.data.url)
+    await deletionWaiter
 
     expect(attachmentIDs[0]).toEqual(attachmentData.data.url)
     expect(attachmentIDs.length).toEqual(1)

--- a/tests/integration/attachments.test.js
+++ b/tests/integration/attachments.test.js
@@ -373,17 +373,10 @@ describe("Tests for uploading/deleting attachments through API calls", () => {
       "ProcessorService",
     )
 
-    const db = await cds.connect.to("db")
+    const attachmentsSrv = await cds.connect.to("attachments")
     const attachmentIDs = []
-    db.before("*", (req) => {
-      if (
-        req.event === "CREATE" &&
-        req.target?.name === "cds.outbox.Messages" &&
-        req.query?.INSERT?.entries?.[0]?.msg
-      ) {
-        const msg = JSON.parse(req.query.INSERT.entries[0].msg)
-        attachmentIDs.push(msg.data.url)
-      }
+    attachmentsSrv.before("DeleteAttachment", (req) => {
+      attachmentIDs.push(req.data?.url)
     })
 
     //delete attachment
@@ -397,6 +390,9 @@ describe("Tests for uploading/deleting attachments through API calls", () => {
       incidentID,
       "ProcessorService",
     )
+
+    // Wait for the outbox to dispatch the DeleteAttachment event
+    await waitForDeletion(attachmentData.data.url)
 
     expect(attachmentIDs[0]).toEqual(attachmentData.data.url)
     expect(attachmentIDs.length).toEqual(1)


### PR DESCRIPTION
⬇️ _partially AI generated_ ⬇️ 

## Why

Failing test in cds outbound qualification. The "Deleting the attachment" test in `tests/integration/attachments.test.js` spied on the
`db` service for `CREATE` events with an `INSERT` query against `cds.outbox.Messages` to
count `DeleteAttachment` emissions. This was tightly coupled to a CAP-internal detail —
how the outbox/queue persists messages.

Recent CAP changes (`cds.requires.scheduling: true` is now the default) switched the
queue implementation from `INSERT` to `UPSERT` against the same outbox table. The spy's
filter (`req.event === "CREATE"` + `req.query.INSERT.entries`) no longer matches, so
`attachmentIDs` stays empty and the test fails with:

```
Expected: "<attachment-uuid>"
Received: undefined
```

The deletion behavior itself is unchanged.

## What

- Replace the DB-level outbox spy with a `before("DeleteAttachment")` listener on the
  connected `attachments` service. This observes the contract the plugin actually emits,
  not how CAP happens to persist it.
- Add `await waitForDeletion(...)` after the draft save — outbox dispatch is async, so
  we have to wait for the queue to flush before counting. The helper was already imported
  and is used elsewhere in the file (lines 1692, 1744, 1870).