### PR TITLE
test(integration): also load sqlite plugin

### DIFF
--- a/tests/incidents-app/package.json
+++ b/tests/incidents-app/package.json
@@ -7,6 +7,9 @@
     "@cap-js/hana": "2.6.0",
     "@cap-js/postgres": "^2.2.0"
   },
+  "devDependencies": {
+    "@cap-js/sqlite": "*"
+  },
   "cds": {
     "fiori": {
       "bypass_draft": true


### PR DESCRIPTION
it also works today because of the underlying `generic-pool` module which by default also has set `max: 1` . With the next version of the database services we will use our builtin pool which has different defaults.