### PR TITLE
docs: fix typos / grammar in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ With the steps above, we have successfully set up asset handling for our referen
 3. The `Attachments` type has generated an out-of-the-box Attachments table (see 1) at the bottom of the Object page:
    <img width="1300" alt="Attachments Table" style="border-radius:0.5rem;" src="etc/facet.png">
 
-4. **Upload a file** by going into Edit mode and either using the **Upload** button on the Attachments table or by drag/drop. Then click the **Save** button to have that file stored that file in the dedicated resource (database, S3 bucket, etc.). We demonstrate this by uploading the PDF file from [_tests/integration/content/sample.pdf_](./tests/integration/content/sample.pdf):
+4. **Upload a file** by going into Edit mode and either using the **Upload** button on the Attachments table or by drag/drop. Then click the **Save** button to have that file stored in the dedicated resource (database, S3 bucket, etc.). We demonstrate this by uploading the PDF file from [_tests/integration/content/sample.pdf_](./tests/integration/content/sample.pdf):
    <img width="1300" alt="Upload an attachment" style="border-radius:0.5rem;" src="etc/upload.gif">
 
 5. **Delete a file** by going into Edit mode, selecting the file, and pressing the **Delete** button above the Attachments table. Clicking the **Save** button will then delete that file from the resource (database, S3 bucket, etc.).
@@ -596,9 +596,9 @@ For multi-tenant applications, `@cap-js/attachments` must be included in the dep
 
 #### Separate object store instances
 
-By default the plugin creates for each tenant its own object store instance during the tenants subscription.
+By default, the plugin creates its own object store instance for each tenant during the tenant's subscription.
 
-When the tenant unsubscribes the object store instance is deleted.
+When the tenant unsubscribes, the object store instance is deleted.
 
 > [!WARNING]
 > When you remove the plugin from an application after separate object stores already have been created, the object stores are not automatically removed!
@@ -691,7 +691,7 @@ The following table gives an overview of the fields and the i18n codes:
 | `status`   | `ScanStatus` |
 | `note`     | `note`       |
 
-In addition to the field names, header information (`@UI.HeaderInfo`) are also annotated:
+In addition to the field names, header information (`@UI.HeaderInfo`) is also annotated:
 
 | Header Info      | i18n Code     |
 | ---------------- | ------------- |


### PR DESCRIPTION
# Fix Typos and Grammar in README.md

📝 **Documentation**: Corrected several grammatical errors and typos in the README for improved clarity and readability.

### Changes

* `README.md`: Fixed the following issues:
  - Removed duplicate word "stored that file" → "stored in"
  - Added missing comma and improved sentence structure in the multitenancy section: "By default the plugin creates for each tenant its own object store instance during the tenants subscription" → "By default, the plugin creates its own object store instance for each tenant during the tenant's subscription"
  - Added missing comma: "When the tenant unsubscribes the object store instance is deleted" → "When the tenant unsubscribes, the object store instance is deleted"
  - Fixed subject-verb agreement: "header information (`@UI.HeaderInfo`) are also annotated" → "header information (`@UI.HeaderInfo`) is also annotated"

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.22.8`

- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `b6d38b4e-2ead-44f9-bde8-af6bfd66ef16`
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
</details>
