### PR TITLE
chore: update version to 3.13.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cap-js/attachments",
   "description": "CAP cds-plugin providing image and attachment storing out-of-the-box.",
-  "version": "3.12.2",
+  "version": "3.13.0",
   "repository": "cap-js/attachments",
   "author": "SAP SE (https://www.sap.com)",
   "homepage": "https://cap.cloud.sap/",


### PR DESCRIPTION
# Bump Version to 3.13.0

### Chore

🔧 Updated the package version from `3.12.2` to `3.13.0` in `package.json` for the `@cap-js/attachments` plugin.

### Changes

* `package.json`: Incremented the version from `3.12.2` to `3.13.0`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.0`

- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `b36f2813-7d5d-49c7-90b9-fc29a6228e8d`
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
