### PR TITLE
UI Shows Multiple Single Attachment Components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 3.13.1
+
+### Fixed
+
+- Multiple single attachments components now are visible in the UI with unique labels
+
 ## Version 3.13.0
 
 ### Added

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -329,10 +329,16 @@ function unfoldModel(csn) {
           { $Type: "UI.DataField", Value: { "=": `${prefix}_status` } },
         ],
       }
+      const label =
+        entity.elements?.[prefix]?.["@title"] ??
+        (entity._attachments.inlineAttachmentPrefixes.length > 1
+          ? prefix
+          : "{i18n>Attachment}")
       facets.push({
         $Type: "UI.ReferenceFacet",
+        ID: prefix,
         Target: fieldGroupKey,
-        Label: "{i18n>Attachment}",
+        Label: label,
       })
     }
   })

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -330,13 +330,12 @@ function unfoldModel(csn) {
         ],
       }
       const label =
-        entity.elements?.[prefix]?.["@title"] ??
-        (entity._attachments.inlineAttachmentPrefixes.length > 1
+        entity._attachments.inlineAttachmentPrefixes.length > 1
           ? prefix
-          : "{i18n>Attachment}")
+          : "{i18n>Attachment}"
       facets.push({
         $Type: "UI.ReferenceFacet",
-        ID: prefix,
+        ID: `${prefix}_attachment`,
         Target: fieldGroupKey,
         Label: label,
       })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cap-js/attachments",
   "description": "CAP cds-plugin providing image and attachment storing out-of-the-box.",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "repository": "cap-js/attachments",
   "author": "SAP SE (https://www.sap.com)",
   "homepage": "https://cap.cloud.sap/",


### PR DESCRIPTION
# Fix: Multiple Single Attachment Components Showing Duplicate Labels in UI

### Bug Fix

🐛 Resolved an issue where multiple single attachment components were displayed in the UI without unique labels, making them indistinguishable from one another. Each attachment component is now labeled distinctly based on its field title or prefix.

### Changes

* `lib/plugin.js`: Updated the label logic for `UI.ReferenceFacet` entries. The label now resolves as follows:
  1. Uses the field prefix name when multiple inline attachments exist on the same entity.
  2. Defaults to `{i18n>Attachment}` when only a single attachment is present.
  Additionally, a unique `ID` (`prefix`) is now assigned to each facet to ensure uniqueness.
* `CHANGELOG.md`: Added entry for version `3.13.1` documenting the fix.
* `package.json`: Bumped version from `3.13.0` to `3.13.1`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.11`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `cf0f244b-d27f-406c-980b-500262cbaf22`
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
</details>
