### PR TITLE
Fix Action Bug in Regards to Incompatible HANA Versioning

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -69,9 +69,9 @@ runs:
         node-version: ${{ inputs.NODE_VERSION }}
     - run: npm i -g @sap/cds-dk
       shell: bash
-    - run: npm i
-      shell: bash
     - run: npm i @sap/cds
+      shell: bash
+    - run: npm i
       shell: bash
     - run: cd tests/incidents-app && npm i
       shell: bash

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -71,7 +71,7 @@ runs:
       shell: bash
     - run: npm i @sap/cds
       shell: bash
-    - run: npm i
+    - run: npm i --legacy-peer-deps @sap/cds
       shell: bash
     - name: Set node env for HANA
       run: echo "NODE_VERSION_HANA=$(echo ${{ inputs.NODE_VERSION }} | tr . _)" >> $GITHUB_ENV

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -71,7 +71,7 @@ runs:
       shell: bash
     - run: npm i @sap/cds
       shell: bash
-    - run: npm i --legacy-peer-deps @sap/cds
+    - run: npm i
       shell: bash
     - name: Set node env for HANA
       run: echo "NODE_VERSION_HANA=$(echo ${{ inputs.NODE_VERSION }} | tr . _)" >> $GITHUB_ENV

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -73,8 +73,6 @@ runs:
       shell: bash
     - run: npm i
       shell: bash
-    - run: cd tests/incidents-app && npm i
-      shell: bash
     - name: Set node env for HANA
       run: echo "NODE_VERSION_HANA=$(echo ${{ inputs.NODE_VERSION }} | tr . _)" >> $GITHUB_ENV
       shell: bash

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "devDependencies": {
     "@cap-js/cds-test": ">=0",
     "@cap-js/cds-types": "^0.17.0",
-    "@cap-js/hana": "^2.7.0",
-    "@cap-js/sqlite": "^2",
+    "@cap-js/hana": ">=2.7.0",
+    "@cap-js/sqlite": ">=2",
     "@eslint/js": "^10",
     "eslint": "^10",
     "express": "^4.18.2",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "devDependencies": {
     "@cap-js/cds-test": ">=0",
     "@cap-js/cds-types": "^0.17.0",
-    "@cap-js/hana": ">=2.7.0",
-    "@cap-js/sqlite": ">=2",
+    "@cap-js/hana": "^2.7.0",
+    "@cap-js/sqlite": "^2",
     "@eslint/js": "^10",
     "eslint": "^10",
     "express": "^4.18.2",

--- a/tests/incidents-app/package.json
+++ b/tests/incidents-app/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@cap-js/attachments": "file:../../.",
     "@cap-js/audit-logging": "^1.2.0",
-    "@cap-js/hana": "2.6.0",
+    "@cap-js/hana": ">=2.6.0",
     "@cap-js/postgres": "^2.2.0"
   },
   "devDependencies": {

--- a/tests/unit/validateAttachmentMimeType.test.js
+++ b/tests/unit/validateAttachmentMimeType.test.js
@@ -7,6 +7,8 @@ const { axios, POST, PUT, GET } = cds.test(app)
 const { validateAttachmentMimeType } = require("../../lib/generic-handlers")
 const { newIncident } = require("../utils/testUtils")
 
+afterAll(() => cds.disconnect())
+
 describe("validateAttachmentMimeType - Content-Type header bypass security test", () => {
   axios.defaults.auth = { username: "alice" }
 

--- a/tests/unit/validateAttachmentMimeType.test.js
+++ b/tests/unit/validateAttachmentMimeType.test.js
@@ -143,10 +143,6 @@ describe("validateAttachmentMimeType - Content-Type header bypass security test"
 
     expect(expectedError).toBeDefined()
     expect(expectedError.status).toEqual(400)
-
-    // await GET(
-    //   `/odata/v4/admin/Incidents(${incidentID})/mediaTypeAttachments(up__ID=${incidentID},ID=${attachmentID})`,
-    // )
   })
 
   it("should allow upload when file extension matches allowed mimetypes", async () => {
@@ -247,10 +243,6 @@ describe("validateAttachmentMimeType - Content-Type header bypass security test"
     expect(expectedError.response.data.error.message).toContain(
       "application/pdf",
     )
-
-    // await GET(
-    //   `/odata/v4/admin/Incidents(${incidentID})/mediaTypeAttachments(up__ID=${incidentID},ID=${attachmentID})`,
-    // )
   })
 })
 

--- a/tests/unit/validateAttachmentMimeType.test.js
+++ b/tests/unit/validateAttachmentMimeType.test.js
@@ -7,10 +7,14 @@ const { axios, POST, PUT, GET } = cds.test(app)
 const { validateAttachmentMimeType } = require("../../lib/generic-handlers")
 const { newIncident } = require("../utils/testUtils")
 
-afterAll(() => cds.disconnect())
+afterAll(async () => {
+  await cds.disconnect()
+})
 
 describe("validateAttachmentMimeType - Content-Type header bypass security test", () => {
   axios.defaults.auth = { username: "alice" }
+
+  afterEach(() => cds.flush())
 
   /**
    * Security Test: Content-Type Header Bypass Attack
@@ -139,6 +143,10 @@ describe("validateAttachmentMimeType - Content-Type header bypass security test"
 
     expect(expectedError).toBeDefined()
     expect(expectedError.status).toEqual(400)
+
+    // await GET(
+    //   `/odata/v4/admin/Incidents(${incidentID})/mediaTypeAttachments(up__ID=${incidentID},ID=${attachmentID})`,
+    // )
   })
 
   it("should allow upload when file extension matches allowed mimetypes", async () => {
@@ -239,6 +247,10 @@ describe("validateAttachmentMimeType - Content-Type header bypass security test"
     expect(expectedError.response.data.error.message).toContain(
       "application/pdf",
     )
+
+    // await GET(
+    //   `/odata/v4/admin/Incidents(${incidentID})/mediaTypeAttachments(up__ID=${incidentID},ID=${attachmentID})`,
+    // )
   })
 })
 

--- a/tests/unit/validateAttachmentSize.test.js
+++ b/tests/unit/validateAttachmentSize.test.js
@@ -3,11 +3,13 @@ const cds = require("@sap/cds")
 const { readFileSync } = cds.utils.fs
 const { join } = cds.utils.path
 const app = join(__dirname, "../incidents-app")
-const { axios, POST } = cds.test(app)
+const { axios, POST, PUT } = cds.test(app)
 const { validateAttachmentSize } = require("../../lib/generic-handlers")
 const { newIncident } = require("../utils/testUtils")
 
-afterAll(() => cds.disconnect())
+afterAll(async () => {
+  await cds.disconnect()
+})
 
 describe("validateAttachmentSize", () => {
   axios.defaults.auth = { username: "alice" }
@@ -24,7 +26,7 @@ describe("validateAttachmentSize", () => {
       join(__dirname, "..", "integration", "content/sample.pdf"),
     )
 
-    const response = await axios.put(
+    const response = await PUT(
       `/odata/v4/admin/Incidents(${incidentID})/attachments(up__ID=${incidentID},ID=${responseCreate.data.ID})/content`,
       fileContent,
       {

--- a/tests/unit/validateAttachmentSize.test.js
+++ b/tests/unit/validateAttachmentSize.test.js
@@ -7,6 +7,8 @@ const { axios, POST } = cds.test(app)
 const { validateAttachmentSize } = require("../../lib/generic-handlers")
 const { newIncident } = require("../utils/testUtils")
 
+afterAll(() => cds.disconnect())
+
 describe("validateAttachmentSize", () => {
   axios.defaults.auth = { username: "alice" }
 


### PR DESCRIPTION
Install correct version of HANA depending on CDS version. Node 22 installs CDS 10, which is incompatible with HANA 2.x. Adjust action workflow so that a compatible version of HANA is installed for both Node 20 and Node 22.