### PR TITLE
fix: action.yml

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -73,6 +73,10 @@ runs:
       if: ${{ inputs.NODE_VERSION == '20.x' }}
       run: npm i @sap/cds@^9
       shell: bash
+    - name: Install CDS (latest) for other Node versions
+      if: ${{ inputs.NODE_VERSION != '20.x' }}
+      run: npm i @sap/cds
+      shell: bash
     - run: npm i
       shell: bash
     - name: Set node env for HANA

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -69,7 +69,9 @@ runs:
         node-version: ${{ inputs.NODE_VERSION }}
     - run: npm i -g @sap/cds-dk
       shell: bash
-    - run: npm i @sap/cds
+    - name: Install CDS 9 for Node 20
+      if: ${{ inputs.NODE_VERSION == '20.x' }}
+      run: npm i @sap/cds@^9
       shell: bash
     - run: npm i
       shell: bash


### PR DESCRIPTION
# Fix: Conditional `@sap/cds` Installation Based on Node.js Version

### Bug Fix

🐛 Updated the integration tests action to conditionally install `@sap/cds@^9` only when running on Node.js 20.x, replacing the unconditional `npm i @sap/cds` step.

### Changes

* `.github/actions/integration-tests/action.yml`: Replaced the generic `npm i @sap/cds` step with a named step `Install CDS 9 for Node 20` that conditionally runs `npm i @sap/cds@^9` only when `inputs.NODE_VERSION == '20.x'`. This ensures the correct version of `@sap/cds` is installed depending on the Node.js version used in the workflow.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.28.0`

- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- Correlation ID: `c52e4930-8114-11f1-8dec-9cf07c993b2e`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
</details>
