### PR TITLE
Node 20 Test Fix

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -69,11 +69,14 @@ runs:
         node-version: ${{ inputs.NODE_VERSION }}
     - run: npm i -g @sap/cds-dk
       shell: bash
-    - run: npm i
-      shell: bash
-    - name: Pin CDS 9 + HANA 2 for Node 20
+    - name: Pin CDS 9 + HANA 2 + SQLite 2 for Node 20
       if: ${{ inputs.NODE_VERSION == '20.x' }}
-      run: npm i @sap/cds@^9 @cap-js/hana@^2 --no-save --legacy-peer-deps
+      shell: bash
+      run: |
+        npm pkg set peerDependencies.@sap/cds="^9"
+        npm pkg set devDependencies.@cap-js/hana="^2"
+        npm pkg set devDependencies.@cap-js/sqlite="^2"
+    - run: npm i
       shell: bash
     - name: Set node env for HANA
       run: echo "NODE_VERSION_HANA=$(echo ${{ inputs.NODE_VERSION }} | tr . _)" >> $GITHUB_ENV

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -69,15 +69,11 @@ runs:
         node-version: ${{ inputs.NODE_VERSION }}
     - run: npm i -g @sap/cds-dk
       shell: bash
-    - name: Install CDS 9 for Node 20
-      if: ${{ inputs.NODE_VERSION == '20.x' }}
-      run: npm i @sap/cds@^9
-      shell: bash
-    - name: Install CDS (latest) for other Node versions
-      if: ${{ inputs.NODE_VERSION != '20.x' }}
-      run: npm i @sap/cds
-      shell: bash
     - run: npm i
+      shell: bash
+    - name: Pin CDS 9 + HANA 2 for Node 20
+      if: ${{ inputs.NODE_VERSION == '20.x' }}
+      run: npm i @sap/cds@^9 @cap-js/hana@^2
       shell: bash
     - name: Set node env for HANA
       run: echo "NODE_VERSION_HANA=$(echo ${{ inputs.NODE_VERSION }} | tr . _)" >> $GITHUB_ENV

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -73,7 +73,7 @@ runs:
       shell: bash
     - name: Pin CDS 9 + HANA 2 for Node 20
       if: ${{ inputs.NODE_VERSION == '20.x' }}
-      run: npm i @sap/cds@^9 @cap-js/hana@^2
+      run: npm i @sap/cds@^9 @cap-js/hana@^2 --no-save --legacy-peer-deps
       shell: bash
     - name: Set node env for HANA
       run: echo "NODE_VERSION_HANA=$(echo ${{ inputs.NODE_VERSION }} | tr . _)" >> $GITHUB_ENV

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -69,14 +69,11 @@ runs:
         node-version: ${{ inputs.NODE_VERSION }}
     - run: npm i -g @sap/cds-dk
       shell: bash
-    - name: Pin CDS 9 + HANA 2 + SQLite 2 for Node 20
-      if: ${{ inputs.NODE_VERSION == '20.x' }}
-      shell: bash
-      run: |
-        npm pkg set peerDependencies.@sap/cds="^9"
-        npm pkg set devDependencies.@cap-js/hana="^2"
-        npm pkg set devDependencies.@cap-js/sqlite="^2"
     - run: npm i
+      shell: bash
+    - run: npm @sap/cds
+      shell: bash
+    - run: cd tests/incidents-app/ && npm i
       shell: bash
     - name: Set node env for HANA
       run: echo "NODE_VERSION_HANA=$(echo ${{ inputs.NODE_VERSION }} | tr . _)" >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -37,12 +37,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g @sap/cds-dk
-      - name: Pin CDS 9 + HANA 2 + SQLite 2 for Node 20
-        if: ${{ matrix.node-version == '20.x' }}
-        run: |
-          npm pkg set peerDependencies.@sap/cds="^9"
-          npm pkg set devDependencies.@cap-js/hana="^2"
-          npm pkg set devDependencies.@cap-js/sqlite="^2"
       - run: npm i
       - run: npm run test
 
@@ -54,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
         hyperscaler: [AWS, AZURE, GCP]
         scanner-auth: [basic, mtls]
     steps:
@@ -78,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
     services:
       postgres:
         image: postgres:14.5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Pin CDS 9 + HANA 2 for Node 20
         if: ${{ matrix.node-version == '20.x' }}
         run: |
-          npm pkg set overrides.@sap/cds="^9"
-          npm pkg set overrides.@cap-js/hana="^2"
+          npm pkg set peerDependencies.@sap/cds="^9"
+          npm pkg set devDependencies.@cap-js/hana="^2"
       - run: npm i
       - run: npm run test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - run: npm i
       - name: Pin CDS 9 + HANA 2 for Node 20
         if: ${{ matrix.node-version == '20.x' }}
-        run: npm i @sap/cds@^9 @cap-js/hana@^2
+        run: npm i @sap/cds@^9 @cap-js/hana@^2 --no-save --legacy-peer-deps
       - run: npm run test
 
   integration-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g @sap/cds-dk
       - run: npm i
-      - run: cd tests/incidents-app && npm i
+      - name: Pin CDS 9 + HANA 2 for Node 20
+        if: ${{ matrix.node-version == '20.x' }}
+        run: npm i @sap/cds@^9 @cap-js/hana@^2
       - run: npm run test
 
   integration-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,10 +37,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g @sap/cds-dk
-      - run: npm i
       - name: Pin CDS 9 + HANA 2 for Node 20
         if: ${{ matrix.node-version == '20.x' }}
-        run: npm i @sap/cds@^9 @cap-js/hana@^2 --no-save --legacy-peer-deps
+        run: |
+          npm pkg set overrides.@sap/cds="^9"
+          npm pkg set overrides.@cap-js/hana="^2"
+      - run: npm i
       - run: npm run test
 
   integration-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,11 +37,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g @sap/cds-dk
-      - name: Pin CDS 9 + HANA 2 for Node 20
+      - name: Pin CDS 9 + HANA 2 + SQLite 2 for Node 20
         if: ${{ matrix.node-version == '20.x' }}
         run: |
           npm pkg set peerDependencies.@sap/cds="^9"
           npm pkg set devDependencies.@cap-js/hana="^2"
+          npm pkg set devDependencies.@cap-js/sqlite="^2"
       - run: npm i
       - run: npm run test
 


### PR DESCRIPTION
# Fix Node 20 Test Compatibility by Pinning CDS 9 + HANA 2

### Bug Fix

🐛 Resolved test failures on Node 20 by pinning `@sap/cds@^9` and `@cap-js/hana@^2` as a dedicated step after the standard `npm i`, instead of conditionally installing different CDS versions before the general install.

### Changes

* `.github/actions/integration-tests/action.yml`:
  - Removed the previous split steps that conditionally installed either `@sap/cds@^9` (Node 20) or `@sap/cds` (other versions) **before** `npm i`.
  - Added a single new step **"Pin CDS 9 + HANA 2 for Node 20"** that runs **after** `npm i` to pin both `@sap/cds@^9` and `@cap-js/hana@^2` when `NODE_VERSION == '20.x'`.

* `.github/workflows/test.yml`:
  - Removed the `cd tests/incidents-app && npm i` step.
  - Added the same **"Pin CDS 9 + HANA 2 for Node 20"** conditional step after `npm i` to align unit test behavior with integration tests on Node 20.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.28.0`

- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `a9db9830-81c4-11f1-91ed-e4965f3d8686`
</details>
