### PR TITLE
Fix Action

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -69,11 +69,14 @@ runs:
         node-version: ${{ inputs.NODE_VERSION }}
     - run: npm i -g @sap/cds-dk
       shell: bash
-    - run: npm i
-      shell: bash
-    - name: Pin CDS 9 + HANA 2 for Node 20
+    - name: Pin CDS 9 + HANA 2 + SQLite 2 for Node 20
       if: ${{ inputs.NODE_VERSION == '20.x' }}
-      run: npm i @sap/cds@^9 @cap-js/hana@^2 --no-save --legacy-peer-deps
+      shell: bash
+      run: |
+        npm pkg set peerDependencies.@sap/cds="^9"
+        npm pkg set devDependencies.@cap-js/hana="^2"
+        npm pkg set devDependencies.@cap-js/sqlite="^2"
+    - run: npm i
       shell: bash
     - name: Set node env for HANA
       run: echo "NODE_VERSION_HANA=$(echo ${{ inputs.NODE_VERSION }} | tr . _)" >> $GITHUB_ENV

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -69,15 +69,11 @@ runs:
         node-version: ${{ inputs.NODE_VERSION }}
     - run: npm i -g @sap/cds-dk
       shell: bash
-    - name: Install CDS 9 for Node 20
-      if: ${{ inputs.NODE_VERSION == '20.x' }}
-      run: npm i @sap/cds@^9
-      shell: bash
-    - name: Install CDS (latest) for other Node versions
-      if: ${{ inputs.NODE_VERSION != '20.x' }}
-      run: npm i @sap/cds
-      shell: bash
     - run: npm i
+      shell: bash
+    - name: Pin CDS 9 + HANA 2 for Node 20
+      if: ${{ inputs.NODE_VERSION == '20.x' }}
+      run: npm i @sap/cds@^9 @cap-js/hana@^2
       shell: bash
     - name: Set node env for HANA
       run: echo "NODE_VERSION_HANA=$(echo ${{ inputs.NODE_VERSION }} | tr . _)" >> $GITHUB_ENV

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -73,7 +73,7 @@ runs:
       shell: bash
     - name: Pin CDS 9 + HANA 2 for Node 20
       if: ${{ inputs.NODE_VERSION == '20.x' }}
-      run: npm i @sap/cds@^9 @cap-js/hana@^2
+      run: npm i @sap/cds@^9 @cap-js/hana@^2 --no-save --legacy-peer-deps
       shell: bash
     - name: Set node env for HANA
       run: echo "NODE_VERSION_HANA=$(echo ${{ inputs.NODE_VERSION }} | tr . _)" >> $GITHUB_ENV

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -69,14 +69,11 @@ runs:
         node-version: ${{ inputs.NODE_VERSION }}
     - run: npm i -g @sap/cds-dk
       shell: bash
-    - name: Pin CDS 9 + HANA 2 + SQLite 2 for Node 20
-      if: ${{ inputs.NODE_VERSION == '20.x' }}
-      shell: bash
-      run: |
-        npm pkg set peerDependencies.@sap/cds="^9"
-        npm pkg set devDependencies.@cap-js/hana="^2"
-        npm pkg set devDependencies.@cap-js/sqlite="^2"
     - run: npm i
+      shell: bash
+    - run: npm @sap/cds
+      shell: bash
+    - run: cd tests/incidents-app/ && npm i
       shell: bash
     - name: Set node env for HANA
       run: echo "NODE_VERSION_HANA=$(echo ${{ inputs.NODE_VERSION }} | tr . _)" >> $GITHUB_ENV

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -71,10 +71,6 @@ runs:
       shell: bash
     - run: npm i
       shell: bash
-    - run: npm @sap/cds
-      shell: bash
-    - run: cd tests/incidents-app/ && npm i
-      shell: bash
     - name: Set node env for HANA
       run: echo "NODE_VERSION_HANA=$(echo ${{ inputs.NODE_VERSION }} | tr . _)" >> $GITHUB_ENV
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -37,12 +37,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g @sap/cds-dk
-      - name: Pin CDS 9 + HANA 2 + SQLite 2 for Node 20
-        if: ${{ matrix.node-version == '20.x' }}
-        run: |
-          npm pkg set peerDependencies.@sap/cds="^9"
-          npm pkg set devDependencies.@cap-js/hana="^2"
-          npm pkg set devDependencies.@cap-js/sqlite="^2"
       - run: npm i
       - run: npm run test
 
@@ -54,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
         hyperscaler: [AWS, AZURE, GCP]
         scanner-auth: [basic, mtls]
     steps:
@@ -78,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
     services:
       postgres:
         image: postgres:14.5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Pin CDS 9 + HANA 2 for Node 20
         if: ${{ matrix.node-version == '20.x' }}
         run: |
-          npm pkg set overrides.@sap/cds="^9"
-          npm pkg set overrides.@cap-js/hana="^2"
+          npm pkg set peerDependencies.@sap/cds="^9"
+          npm pkg set devDependencies.@cap-js/hana="^2"
       - run: npm i
       - run: npm run test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - run: npm i
       - name: Pin CDS 9 + HANA 2 for Node 20
         if: ${{ matrix.node-version == '20.x' }}
-        run: npm i @sap/cds@^9 @cap-js/hana@^2
+        run: npm i @sap/cds@^9 @cap-js/hana@^2 --no-save --legacy-peer-deps
       - run: npm run test
 
   integration-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g @sap/cds-dk
       - run: npm i
-      - run: cd tests/incidents-app && npm i
+      - name: Pin CDS 9 + HANA 2 for Node 20
+        if: ${{ matrix.node-version == '20.x' }}
+        run: npm i @sap/cds@^9 @cap-js/hana@^2
       - run: npm run test
 
   integration-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,10 +37,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g @sap/cds-dk
-      - run: npm i
       - name: Pin CDS 9 + HANA 2 for Node 20
         if: ${{ matrix.node-version == '20.x' }}
-        run: npm i @sap/cds@^9 @cap-js/hana@^2 --no-save --legacy-peer-deps
+        run: |
+          npm pkg set overrides.@sap/cds="^9"
+          npm pkg set overrides.@cap-js/hana="^2"
+      - run: npm i
       - run: npm run test
 
   integration-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,11 +37,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g @sap/cds-dk
-      - name: Pin CDS 9 + HANA 2 for Node 20
+      - name: Pin CDS 9 + HANA 2 + SQLite 2 for Node 20
         if: ${{ matrix.node-version == '20.x' }}
         run: |
           npm pkg set peerDependencies.@sap/cds="^9"
           npm pkg set devDependencies.@cap-js/hana="^2"
+          npm pkg set devDependencies.@cap-js/sqlite="^2"
       - run: npm i
       - run: npm run test
 


### PR DESCRIPTION
# Update CI/CD Actions: Drop Node 20, Add Node 24, Simplify CDS Install Steps

### Chore

🔧 Updated GitHub Actions workflows and the integration test action to modernize the Node.js version matrix and simplify CDS package installation steps.

### Changes

* `.github/workflows/test.yml`:
  - Updated Node.js version matrix from `[20.x, 22.x]` to `[22.x, 24.x]` across all three job strategies (`test`, `integration-tests`, `integration-tests-postgres`).
  - Removed the redundant `cd tests/incidents-app && npm i` step from the `test` job.

* `.github/actions/integration-tests/action.yml`:
  - Removed the conditional CDS version installation steps that previously installed `@sap/cds@^9` for Node 20 and the latest `@sap/cds` for other versions. These are replaced by a single unconditional `npm i` step, relying on the project's `package.json` to resolve the correct CDS version.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.28.0`

- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `d5097850-81d9-11f1-8432-72299b80d7c4`
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
</details>
