### PR TITLE
fix: integrate updated cds.odata.urlify api

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -790,8 +790,9 @@ cds.ApplicationService.handle_attachments = cds.service.impl(async function () {
         data[`min${compName}Target`] ?? comp["@Validation.MinItems"]
       const maxTarget =
         data[`max${compName}Target`] ?? comp["@Validation.MaxItems"]
+
       const { path: url } = cds.odata.urlify(
-        SELECT.from({ ref: path.concat(compName) }),
+        { query: SELECT.from({ ref: path.concat(compName) }), subject: { ref: path.concat(compName) } },
         { model: cds.context.model ?? cds.model },
       )
       // Remove first part of URL because CAP adds that themselves


### PR DESCRIPTION
An intended update to the internal `cds.odata.urlify` API will require this change. 