### PR TITLE
Fork Fix - Adjust unit tests

### DIFF
--- a/tests/unit/unitTests.test.js
+++ b/tests/unit/unitTests.test.js
@@ -1,35 +1,3 @@
-const mockLogInstance = {
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-  debug: jest.fn(),
-  _debug: true,
-}
-
-const mockRedacted = jest.fn((cred) => {
-  if (!cred || typeof cred !== "object") return cred
-  const result = {}
-  for (const k of Object.keys(cred)) {
-    result[k] =
-      /(passw)|(cert)|(ca)|(secret)|(key)/i.test(k) &&
-      typeof cred[k] === "string"
-        ? "..."
-        : cred[k]
-  }
-  return result
-})
-
-jest.mock("@sap/cds", () => ({
-  ql: { UPDATE: jest.fn(() => ({ with: jest.fn() })) },
-  debug: jest.fn(),
-  log: jest.fn(() => mockLogInstance),
-  Service: class {},
-  env: { requires: {} },
-  utils: {
-    redacted: mockRedacted,
-  },
-}))
-
 global.fetch = jest.fn()
 
 jest.doMock("../../srv/malware-scanner/malwareScanner", () => {
@@ -43,6 +11,7 @@ jest.doMock("../../srv/malware-scanner/malwareScanner", () => {
   }
 })
 
+const cds = require("@sap/cds")
 const {
   getObjectStoreCredentials,
   fetchToken,
@@ -50,7 +19,6 @@ const {
   MAX_FILE_SIZE,
   validateServiceManagerCredentials,
 } = require("../../lib/helper")
-const cds = require("@sap/cds")
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -184,9 +152,17 @@ describe("size to byte converter", () => {
 })
 
 describe("validateServiceManagerCredentials - no credential leakage", () => {
+  let redactedSpy
+  let consoleErrorSpy
+
   beforeEach(() => {
-    mockLogInstance.error.mockClear()
-    mockRedacted.mockClear()
+    redactedSpy = jest.spyOn(cds.utils, "redacted")
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    redactedSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
   })
 
   it("should not expose raw credentials in LOG.error when fields are missing", () => {
@@ -203,17 +179,14 @@ describe("validateServiceManagerCredentials - no credential leakage", () => {
       validateServiceManagerCredentials(sensitiveCredentials),
     ).toThrow("Missing Service Manager credentials")
 
-    expect(mockLogInstance.error).toHaveBeenCalled()
-    const loggedArgs = mockLogInstance.error.mock.calls[0]
-    const loggedString = JSON.stringify(loggedArgs)
+    // cds.utils.redacted must have been called with the credentials
+    expect(redactedSpy).toHaveBeenCalledWith(sensitiveCredentials)
 
-    // Must NOT contain raw secret values
+    // Verify raw secrets never reached console
+    const loggedString = JSON.stringify(consoleErrorSpy.mock.calls)
     expect(loggedString).not.toContain("super-secret-value")
     expect(loggedString).not.toContain("-----BEGIN CERTIFICATE-----")
     expect(loggedString).not.toContain("-----BEGIN PRIVATE KEY-----")
-
-    // cds.utils.redacted must have been called
-    expect(mockRedacted).toHaveBeenCalledWith(sensitiveCredentials)
   })
 
   it("should pass redacted object to LOG.error, not original", () => {
@@ -229,15 +202,15 @@ describe("validateServiceManagerCredentials - no credential leakage", () => {
       validateServiceManagerCredentials(sensitiveCredentials),
     ).toThrow()
 
-    const loggedArgs = mockLogInstance.error.mock.calls[0]
-    // Second arg is what was passed as the credentials object
-    const loggedCreds = loggedArgs[1]
+    // Verify raw secrets never reached console
+    const loggedString = JSON.stringify(consoleErrorSpy.mock.calls)
+    expect(loggedString).not.toContain("do-not-leak")
+    expect(loggedString).not.toContain("private-key-content")
 
-    // Redacted fields should be masked
-    expect(loggedCreds.clientsecret).toBe("...")
-    expect(loggedCreds.key).toBe("...")
-    // Non-secret fields preserved
-    expect(loggedCreds.sm_url).toBe("https://sm.example.com")
-    expect(loggedCreds.url).toBe("https://token.example.com")
+    // Redacted values should appear instead
+    expect(loggedString).toContain("...")
+    // Non-secret fields preserved in output
+    expect(loggedString).toContain("https://sm.example.com")
+    expect(loggedString).toContain("https://token.example.com")
   })
 })


### PR DESCRIPTION
# Refactor Unit Tests: Replace Manual Mocks with Jest Spies for `@sap/cds`

### Refactor

♻️ Refactored unit tests to remove manual mock definitions for `@sap/cds` and replace them with proper Jest spy-based approaches, improving test reliability and alignment with how the module is actually used.

### Changes

* `tests/unit/unitTests.test.js`:
  - Removed the manually defined `mockLogInstance` and `mockRedacted` mock objects, along with the `jest.mock("@sap/cds", ...)` block that overrode the entire module.
  - `@sap/cds` is now `require`d directly after `jest.doMock` setup, allowing tests to interact with the real module shape.
  - In the `validateServiceManagerCredentials - no credential leakage` describe block, replaced `mockLogInstance.error` and `mockRedacted` usage with `jest.spyOn` on `cds.utils.redacted` and `console.error`.
  - Added `beforeEach` and `afterEach` hooks to set up and restore spies cleanly between tests.
  - Updated assertions to check that `cds.utils.redacted` was called with the sensitive credentials and that raw secret values never appear in `console.error` output, rather than asserting on specific mock call arguments or object property values.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.2`

- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
- Correlation ID: `3aa774b0-8a6c-11f1-91bc-a8296c97508a`
</details>
