### PR TITLE
fix: scan status race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 3.13.4 - 2026-07-28
+
+### Fixed
+
+- Attachment status is now committed as `Scanning` before the re-scan is triggered, preventing a race condition where a download could observe a stale scan status.
+
 ## Version 3.13.3 - 2026-07-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Version 3.13.4 - 2026-07-28
+## Version 3.13.4 - 2026-07-30
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- Attachment status is now committed as `Scanning` before the re-scan is triggered, preventing a race condition where a download could observe a stale scan status.
+- Fixed a race condition where a download-triggered re-scan could leave an attachment stuck in `Scanning` (causing clean files to be rejected on download). The redundant request-path status write in `rescan` has been removed; the spawned scan (`_scanAttachmentsFile`) already sets the status to `Scanning` as its first step. This also avoids holding a DB connection across the request rejection, which could drain the pool on single-connection databases.
 
 ## Version 3.13.3 - 2026-07-24
 

--- a/lib/generic-handlers.js
+++ b/lib/generic-handlers.js
@@ -316,7 +316,7 @@ async function rescan(req, attachmentId, prefix, url) {
 
   if (req.target?._attachments?.isAttachmentsEntity) {
     // Set status to Scanning and commit before emitting event to prevent race conditions
-    cds.tx(
+    await cds.tx(
       async () => await malwareScanner.updateStatus(target, keys, "Scanning"),
     )
     // Trigger scanning in separate transaction as req.reject closes the current transaction
@@ -328,7 +328,7 @@ async function rescan(req, attachmentId, prefix, url) {
         }),
     )
   } else {
-    cds.tx(
+    await cds.tx(
       async () =>
         await UPDATE(req.target, keys).set({
           [`${prefix}_status`]: "Scanning",

--- a/lib/generic-handlers.js
+++ b/lib/generic-handlers.js
@@ -297,7 +297,10 @@ async function validateAttachment(req) {
 
 /**
  * Triggers a malware rescan for an attachment and rejects the current request with 202.
- * Updates the scan status to "Scanning" before emitting the scan event to prevent race conditions.
+ * The status is set to "Scanning" by the spawned scan (_scanAttachmentsFile) as its first step,
+ * so no request-path status write is performed here. Doing so previously (via cds.tx) held a
+ * DB connection across the 202 throw and contended with the detached scan transaction for the
+ * pool, which could leave the row stuck in "Scanning" and, on single-connection databases, drain the pool.
  * @param {import('@sap/cds').Request} req - The request object
  * @param {string} attachmentId - The ID of the attachment to rescan
  * @param {string} [prefix] - The field prefix for inline attachments; undefined for composition-based entities
@@ -315,11 +318,7 @@ async function rescan(req, attachmentId, prefix, url) {
   const malwareScanner = await cds.connect.to("malwareScanner")
 
   if (req.target?._attachments?.isAttachmentsEntity) {
-    // Set status to Scanning and commit before emitting event to prevent race conditions
-    await cds.tx(
-      async () => await malwareScanner.updateStatus(target, keys, "Scanning"),
-    )
-    // Trigger scanning in separate transaction as req.reject closes the current transaction
+    // Trigger scanning in separate transaction as req.reject closes the current transaction.
     cds.spawn(
       async () =>
         await malwareScanner.emit("ScanAttachmentsFile", {
@@ -328,12 +327,6 @@ async function rescan(req, attachmentId, prefix, url) {
         }),
     )
   } else {
-    await cds.tx(
-      async () =>
-        await UPDATE(req.target, keys).set({
-          [`${prefix}_status`]: "Scanning",
-        }),
-    )
     cds.spawn(
       async () =>
         await malwareScanner.emit("ScanAttachmentsFile", {

--- a/tests/unit/rejectionEvents.test.js
+++ b/tests/unit/rejectionEvents.test.js
@@ -529,4 +529,110 @@ describe("Rescan triggered for Unscanned attachment", () => {
     expect(cds.spawn).not.toHaveBeenCalled()
     expect(req.reject).not.toHaveBeenCalled()
   })
+
+  it("should commit the Scanning status before throwing 202 (attachments entity)", async () => {
+    const target = cds.model.definitions["AdminService.Incidents.attachments"]
+
+    attachmentsSvc.getStatus = jest.fn().mockResolvedValue({
+      status: "Unscanned",
+      lastScan: null,
+    })
+
+    // Gate the status commit so we can assert the throw waits for it. If
+    // cds.tx were not awaited, the 202 would be thrown before this resolves.
+    let releaseCommit
+    const commitGate = new Promise((resolve) => {
+      releaseCommit = resolve
+    })
+    cds.tx = jest.fn().mockImplementation(async (fn) => {
+      await commitGate
+      return await fn()
+    })
+
+    const attachmentId = cds.utils.uuid()
+    const req = {
+      target,
+      data: { ID: attachmentId },
+      req: { url: "/some/path/content" },
+      query: { SELECT: { columns: [] } },
+      params: [{ ID: attachmentId }],
+      reject: jest.fn(),
+    }
+
+    cds.env.requires.attachments = { scan: true }
+
+    let gateReleased = false
+    let settledEarly = false
+    const validation = require("../../lib/generic-handlers")
+      .validateAttachment(req)
+      .catch((err) => err)
+    validation.then(() => {
+      settledEarly = !gateReleased
+    })
+
+    // Drain microtasks: while the commit gate is closed, validateAttachment
+    // must not have settled. Without the await on cds.tx, it would already
+    // have thrown the 202 here.
+    await new Promise((r) => setImmediate(r))
+    expect(settledEarly).toBe(false)
+
+    gateReleased = true
+    releaseCommit()
+
+    const result = await validation
+    expect(result).toMatchObject({
+      status: 202,
+      code: "UnableToDownloadAttachmentScanStatusExpired",
+    })
+    expect(malwareScannerSvc.updateStatus).toHaveBeenCalledWith(
+      target.name,
+      { ID: attachmentId },
+      "Scanning",
+    )
+    // The scan itself is triggered fire-and-forget after the commit.
+    expect(cds.spawn).toHaveBeenCalledWith(expect.any(Function))
+  })
+
+  it("should commit the Scanning status before spawning the scan and throwing", async () => {
+    const target = cds.model.definitions["AdminService.Incidents.attachments"]
+
+    attachmentsSvc.getStatus = jest.fn().mockResolvedValue({
+      status: "Unscanned",
+      lastScan: null,
+    })
+
+    const order = []
+    cds.tx = jest.fn().mockImplementation(async (fn) => {
+      const result = await fn()
+      order.push("commit")
+      return result
+    })
+    cds.spawn = jest.fn().mockImplementation((fn) => {
+      order.push("spawn")
+      spawnCallback = fn
+      return { on: jest.fn() }
+    })
+
+    const attachmentId = cds.utils.uuid()
+    const req = {
+      target,
+      data: { ID: attachmentId },
+      req: { url: "/some/path/content" },
+      query: { SELECT: { columns: [] } },
+      params: [{ ID: attachmentId }],
+      reject: jest.fn(),
+    }
+
+    cds.env.requires.attachments = { scan: true }
+
+    try {
+      await require("../../lib/generic-handlers").validateAttachment(req)
+    } catch {
+      order.push("throw")
+    }
+
+    // The Scanning commit must complete before the scan is spawned and
+    // before the 202 is thrown.
+    expect(order).toEqual(["commit", "spawn", "throw"])
+  })
 })

--- a/tests/unit/rejectionEvents.test.js
+++ b/tests/unit/rejectionEvents.test.js
@@ -530,23 +530,12 @@ describe("Rescan triggered for Unscanned attachment", () => {
     expect(req.reject).not.toHaveBeenCalled()
   })
 
-  it("should commit the Scanning status before throwing 202 (attachments entity)", async () => {
+  it("should not write status on the request path, but spawn the scan and throw 202 (attachments entity)", async () => {
     const target = cds.model.definitions["AdminService.Incidents.attachments"]
 
     attachmentsSvc.getStatus = jest.fn().mockResolvedValue({
       status: "Unscanned",
       lastScan: null,
-    })
-
-    // Gate the status commit so we can assert the throw waits for it. If
-    // cds.tx were not awaited, the 202 would be thrown before this resolves.
-    let releaseCommit
-    const commitGate = new Promise((resolve) => {
-      releaseCommit = resolve
-    })
-    cds.tx = jest.fn().mockImplementation(async (fn) => {
-      await commitGate
-      return await fn()
     })
 
     const attachmentId = cds.utils.uuid()
@@ -561,39 +550,27 @@ describe("Rescan triggered for Unscanned attachment", () => {
 
     cds.env.requires.attachments = { scan: true }
 
-    let gateReleased = false
-    let settledEarly = false
-    const validation = require("../../lib/generic-handlers")
+    const result = await require("../../lib/generic-handlers")
       .validateAttachment(req)
       .catch((err) => err)
-    validation.then(() => {
-      settledEarly = !gateReleased
-    })
 
-    // Drain microtasks: while the commit gate is closed, validateAttachment
-    // must not have settled. Without the await on cds.tx, it would already
-    // have thrown the 202 here.
-    await new Promise((r) => setImmediate(r))
-    expect(settledEarly).toBe(false)
-
-    gateReleased = true
-    releaseCommit()
-
-    const result = await validation
     expect(result).toMatchObject({
       status: 202,
       code: "UnableToDownloadAttachmentScanStatusExpired",
     })
-    expect(malwareScannerSvc.updateStatus).toHaveBeenCalledWith(
-      target.name,
-      { ID: attachmentId },
-      "Scanning",
-    )
-    // The scan itself is triggered fire-and-forget after the commit.
+
+    // The request path must NOT write the scan status itself. The spawned scan
+    // (_scanAttachmentsFile) sets "Scanning" as its first step. A request-path
+    // write would hold a DB connection across the 202 throw and race the scan's
+    // own status writes (regression: attachment stuck in "Scanning").
+    expect(malwareScannerSvc.updateStatus).not.toHaveBeenCalled()
+    expect(cds.tx).not.toHaveBeenCalled()
+
+    // The scan is triggered fire-and-forget.
     expect(cds.spawn).toHaveBeenCalledWith(expect.any(Function))
   })
 
-  it("should commit the Scanning status before spawning the scan and throwing", async () => {
+  it("should spawn the ScanAttachmentsFile event with the correct payload", async () => {
     const target = cds.model.definitions["AdminService.Incidents.attachments"]
 
     attachmentsSvc.getStatus = jest.fn().mockResolvedValue({
@@ -601,15 +578,9 @@ describe("Rescan triggered for Unscanned attachment", () => {
       lastScan: null,
     })
 
-    const order = []
-    cds.tx = jest.fn().mockImplementation(async (fn) => {
-      const result = await fn()
-      order.push("commit")
-      return result
-    })
+    let spawnedFn
     cds.spawn = jest.fn().mockImplementation((fn) => {
-      order.push("spawn")
-      spawnCallback = fn
+      spawnedFn = fn
       return { on: jest.fn() }
     })
 
@@ -625,14 +596,18 @@ describe("Rescan triggered for Unscanned attachment", () => {
 
     cds.env.requires.attachments = { scan: true }
 
-    try {
-      await require("../../lib/generic-handlers").validateAttachment(req)
-    } catch {
-      order.push("throw")
-    }
+    await require("../../lib/generic-handlers")
+      .validateAttachment(req)
+      .catch((err) => err)
 
-    // The Scanning commit must complete before the scan is spawned and
-    // before the 202 is thrown.
-    expect(order).toEqual(["commit", "spawn", "throw"])
+    expect(cds.spawn).toHaveBeenCalledTimes(1)
+
+    // Running the spawned function emits the scan event that the malware
+    // scanner consumes to perform the scan and set the status.
+    await spawnedFn()
+    expect(malwareScannerSvc.emit).toHaveBeenCalledWith("ScanAttachmentsFile", {
+      target: target.name,
+      keys: { ID: attachmentId },
+    })
   })
 })


### PR DESCRIPTION
Closes #432
Related to #481

## Problem

Clean attachments intermittently returned a 202/stuck-in-Scanning state on download, because the download-triggered re-scan in `rescan()` (`lib/generic-handlers.js`) wrote the status to `Scanning `in a non-awaited `cds.tx(...)` before spawning the scan:

```ts
// Set status to Scanning and commit before emitting event to prevent race conditions
cds.tx(async () => await malwareScanner.updateStatus(target, keys, "Scanning"))  // NOT awaited
cds.spawn(async () => await malwareScanner.emit("ScanAttachmentsFile", { target, keys }))
throw cds.error({ status: 202, code: "UnableToDownloadAttachmentScanStatusExpired" })
```

The comment promised "commit before emitting", but the `cds.tx` is not awaited, so there is no happens-before guarantee. The spawned scan (`_scanAttachmentsFile`) also sets `Scanning` as its first step and later writes `Clean`. Under load the un-awaited `Scanning` commit is starved on the DB connection pool and lands after the scan's Clean commit → last-writer-wins → row stuck in Scanning (visible in logs as Updated scan status to `Scanning` for undefined, since rescan passes `req.target.name` as a string).

##  Fix
  Remove the request-path Scanning write entirely (both the composition and inline-attachment branches), leaving only the cds.spawn that triggers the scan.

This is correct because the write was redundant, not load-bearing: `_scanAttachmentsFile` already sets the status to Scanning as its first committed step. Removing it:
  - eliminates the duplicate/late write that clobbered Clean (no stuck-in-Scanning), and
  - avoids holding a DB connection across the 202 throw, which contended with the detached scan transaction for the pool.

I reverted my earlier attempt (await cds.tx(...)). I first tried making the write safe by awaiting the `cds.tx(...)`. That fixed the ordering but made things worse in a different way: the awaited commit holds a DB connection across the 202 throw and collides with the detached `cds.spawn` scan transaction. On a single-connection database (local SQLite dev server + test harness) this drained the pool (Pool is draining / database is not open) and hung the reques — reproducible on a UI-triggered rescan in local dev if you have additional things happening afterwards like audit log writes. Removing the write (rather than awaiting it) avoids both failure modes.

##  Relationship to #442
Draft PR #442 takes the same removal approach. This PR arrives at the same conclusion independently, with the added data point that the await-the-tx alternative is not viable (pool drain on single-connection DBs). Happy to consolidate with #442 if you prefer that.

## Out of scope

#481 (attachment stuck in Scanning after a crash between the Scanning and Clean writes) is a separate crash-recovery concern and is not addressed here.