### PR TITLE
fix: scan-status gate bypassed by /content/$value requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Unreleased]
+
+### Fixed
+
+- Malware-scan-status gate bypassed by `/content/$value`: `validateAttachment` now recognises the OData `/$value` suffix as a content request and enforces scan policy accordingly. The `getScanInfo` prefix extraction is also corrected for `/$value` URLs (CWE-184).
+
 ## Version 4.0.0 - 2026-08-03
 
 **BREAKING CHANGE: The attachments plugin comes now without hyperscaler dependencies, please make sure to install them accordingly!**

--- a/lib/generic-handlers.js
+++ b/lib/generic-handlers.js
@@ -1,7 +1,13 @@
 const cds = require("@sap/cds")
 const LOG = cds.log("attachments")
 const { extname } = require("path")
-const { MAX_FILE_SIZE, sizeInBytes, checkMimeTypeMatch } = require("./helper")
+const {
+  MAX_FILE_SIZE,
+  sizeInBytes,
+  checkMimeTypeMatch,
+  isContentRequest,
+  extractContentPrefix,
+} = require("./helper")
 const { getMime } = require("./mime")
 
 /**
@@ -161,7 +167,7 @@ async function getScanInfo(req, reqUrl, AttachmentsSrv) {
     return { status, lastScan, attachmentId: id }
   }
 
-  const prefix = reqUrl.split("/").pop().replace("_content", "")
+  const prefix = extractContentPrefix(reqUrl)
   const dbKeys = Object.fromEntries(
     Object.entries(req.target.keys)
       .map(([key]) => [
@@ -272,8 +278,7 @@ async function validateAttachment(req) {
   }
 
   const reqUrl = req?.req?.url
-
-  if (reqUrl?.endsWith("/content") || /\/[^/]*_content$/.test(reqUrl)) {
+  if (isContentRequest(reqUrl)) {
     const AttachmentsSrv = await cds.connect.to("attachments")
 
     const scanInfo = await getScanInfo(req, reqUrl, AttachmentsSrv)
@@ -346,13 +351,7 @@ async function readAttachment([attachment], req) {
   )
     return
 
-  if (
-    req._.readAfterWrite ||
-    !(
-      req?.req?.url?.endsWith("/content") || req?.req?.url?.match(/_content$/)
-    ) ||
-    !attachment
-  )
+  if (req._.readAfterWrite || !isContentRequest(req?.req?.url) || !attachment)
     return
 
   const AttachmentsSrv = await cds.connect.to("attachments")
@@ -365,7 +364,7 @@ async function readAttachment([attachment], req) {
       null,
     )
   } else {
-    const prefix = req.req.url.split("/").pop().replace("_content", "")
+    const prefix = extractContentPrefix(req.req.url)
     const contentField = `${prefix}_content`
     if (attachment[contentField]) return
     const parentKeys = Object.fromEntries(

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -907,7 +907,24 @@ function createSizeCheckHandler({
   return { handler, getSizeExceeded, createError }
 }
 
+function isContentRequest(url) {
+  const path = url?.split("?")[0].split("#")[0]
+  return /(?:^|\/)(?:[^/]+_content|content)(?:\/\$value)?$/.test(path)
+}
+
+function extractContentPrefix(url) {
+  const path = url?.split("?")[0].split("#")[0] ?? ""
+  const seg = path
+    .replace(/\/\$value$/, "")
+    .split("/")
+    .pop()
+  if (!seg || seg === "content") return undefined
+  return seg.replace(/_content$/, "") || undefined
+}
+
 module.exports = {
+  isContentRequest,
+  extractContentPrefix,
   fetchToken,
   getObjectStoreCredentials,
   computeHash,

--- a/tests/unit/contentUrlHelpers.test.js
+++ b/tests/unit/contentUrlHelpers.test.js
@@ -1,0 +1,79 @@
+"use strict"
+const { isContentRequest, extractContentPrefix } = require("../../lib/helper")
+
+describe("isContentRequest", () => {
+  it.each([
+    "/odata/v4/processor/Incidents(1)/attachments(ID=1)/content",
+    "/odata/v4/processor/Incidents(1)/attachments(ID=1)/content/$value",
+    "/odata/v4/processor/Entity(1)/foo_content",
+    "/odata/v4/processor/Entity(1)/foo_content/$value",
+    "content",
+    "content/$value",
+  ])("returns true for %s", (url) => {
+    expect(isContentRequest(url)).toBe(true)
+  })
+
+  it.each([
+    "/odata/v4/processor/Incidents",
+    "/odata/v4/processor/Incidents(1)",
+    "/odata/v4/processor/Incidents(1)/attachments",
+    "/content/extra/segment",
+    "/content/$value/extra",
+    "",
+    null,
+    undefined,
+  ])("returns false for %s", (url) => {
+    expect(isContentRequest(url)).toBe(false)
+  })
+
+  it("strips query string before matching", () => {
+    expect(isContentRequest("/Incidents(1)/content?sap-client=100")).toBe(true)
+    expect(isContentRequest("/Incidents(1)/content/$value?foo=bar")).toBe(true)
+  })
+
+  it("strips fragment before matching", () => {
+    expect(isContentRequest("/Incidents(1)/content#section")).toBe(true)
+  })
+})
+
+describe("extractContentPrefix", () => {
+  it("returns undefined for plain /content", () => {
+    expect(
+      extractContentPrefix("/Incidents(1)/attachments(ID=1)/content"),
+    ).toBeUndefined()
+  })
+
+  it("returns undefined for /content/$value", () => {
+    expect(
+      extractContentPrefix("/Incidents(1)/attachments(ID=1)/content/$value"),
+    ).toBeUndefined()
+  })
+
+  it("returns the prefix for /foo_content", () => {
+    expect(extractContentPrefix("/Entity(1)/foo_content")).toBe("foo")
+  })
+
+  it("returns the prefix for /foo_content/$value", () => {
+    expect(extractContentPrefix("/Entity(1)/foo_content/$value")).toBe("foo")
+  })
+
+  it("returns the prefix for a multi-word field like /my_field_content/$value", () => {
+    expect(extractContentPrefix("/Entity(1)/my_field_content/$value")).toBe(
+      "my_field",
+    )
+  })
+
+  it("strips query string before extracting prefix", () => {
+    expect(extractContentPrefix("/Entity(1)/foo_content?sap-client=100")).toBe(
+      "foo",
+    )
+    expect(extractContentPrefix("/Entity(1)/foo_content/$value?foo=bar")).toBe(
+      "foo",
+    )
+  })
+
+  it("returns undefined for null/undefined", () => {
+    expect(extractContentPrefix(null)).toBeUndefined()
+    expect(extractContentPrefix(undefined)).toBeUndefined()
+  })
+})

--- a/tests/unit/status-gate.test.js
+++ b/tests/unit/status-gate.test.js
@@ -25,7 +25,7 @@ beforeEach(() => {
   })
 
   originalSpawn = cds.spawn
-  cds.spawn = jest.fn().mockImplementation((fn) => {
+  cds.spawn = jest.fn().mockImplementation((_fn) => {
     return { on: jest.fn() }
   })
 

--- a/tests/unit/status-gate.test.js
+++ b/tests/unit/status-gate.test.js
@@ -1,0 +1,112 @@
+"use strict"
+require("../../lib/csn-runtime-extension")
+const cds = require("@sap/cds")
+const path = require("path")
+
+const app = path.join(__dirname, "../incidents-app")
+cds.test(app)
+
+let attachmentsSvc
+let originalConnectTo
+let originalSpawn
+let originalTx
+
+beforeEach(() => {
+  jest.restoreAllMocks()
+
+  attachmentsSvc = {
+    emit: jest.fn().mockResolvedValue(undefined),
+    getStatus: jest.fn(),
+  }
+  originalConnectTo = cds.connect.to
+  cds.connect.to = jest.fn().mockImplementation((name) => {
+    if (name === "attachments") return Promise.resolve(attachmentsSvc)
+    return originalConnectTo.call(cds.connect, name)
+  })
+
+  originalSpawn = cds.spawn
+  cds.spawn = jest.fn().mockImplementation((fn) => {
+    return { on: jest.fn() }
+  })
+
+  originalTx = cds.tx
+  cds.tx = jest.fn().mockImplementation(async (fn) => await fn())
+})
+
+afterEach(() => {
+  cds.connect.to = originalConnectTo
+  cds.spawn = originalSpawn
+  cds.tx = originalTx
+  cds.env.requires.attachments = undefined
+})
+
+describe("scan-status gate for /content and /content/$value", () => {
+  /**
+   * Helper that calls validateAttachment with a given URL and an Infected status.
+   * Returns the result of the call (or throws if the handler throws/rejects).
+   */
+  async function callValidateWithUrl(url) {
+    const target = cds.model.definitions["AdminService.Incidents.attachments"]
+    const attachmentId = cds.utils.uuid()
+
+    attachmentsSvc.getStatus = jest.fn().mockResolvedValue({
+      status: "Infected",
+      lastScan: new Date().toISOString(),
+    })
+
+    const req = {
+      target,
+      data: { ID: attachmentId },
+      req: { url },
+      query: { SELECT: { columns: [] } },
+      params: [{ ID: attachmentId }],
+      reject: jest.fn(),
+    }
+
+    cds.env.requires.attachments = { scan: true }
+
+    await require("../../lib/generic-handlers").validateAttachment(req)
+    return req
+  }
+
+  it("GET /content on Infected attachment calls req.reject(403)", async () => {
+    const req = await callValidateWithUrl(
+      "/odata/v4/processor/Incidents/content",
+    )
+    expect(req.reject).toHaveBeenCalledWith(
+      403,
+      "UnableToDownloadAttachmentScanStatusNotClean",
+    )
+  })
+
+  it("[BUG] GET /content/$value on Infected attachment must also call req.reject(403)", async () => {
+    // Currently fails because endsWith('/content') and /\/[^/]*_content$/ both
+    // miss the /$value suffix — the gate is never entered.
+    const req = await callValidateWithUrl(
+      "/odata/v4/processor/Incidents/content/$value",
+    )
+    expect(req.reject).toHaveBeenCalledWith(
+      403,
+      "UnableToDownloadAttachmentScanStatusNotClean",
+    )
+  })
+
+  it("GET /foo_content/$value on Infected inline attachment must also call req.reject(403)", async () => {
+    // Inline attachment variant — also broken before the fix
+    const req = await callValidateWithUrl(
+      "/odata/v4/processor/Entity(ID=1)/foo_content/$value",
+    )
+    // For inline attachments, getScanInfo takes a different code path (not isAttachmentsEntity)
+    // so if the gate IS entered, getStatus won't be called, but reject still should be called
+    // if the scan path works. This test primarily verifies the gate is entered.
+    // (For simplicity we only check that the req was processed past the gate check)
+    // The gate check is: isContentRequest(reqUrl) must return true for this URL.
+    // After fix: isContentRequest returns true, getScanInfo is called.
+    // Since target is AdminService.Incidents.attachments (isAttachmentsEntity=true),
+    // getStatus will be called and rejection will happen.
+    expect(req.reject).toHaveBeenCalledWith(
+      403,
+      "UnableToDownloadAttachmentScanStatusNotClean",
+    )
+  })
+})


### PR DESCRIPTION
## Problem

Infected attachments could be downloaded via the OData `/$value` suffix (`GET /content/$value`) because the scan-status gate in `validateAttachment` only checked for `/content` and `/_content` suffixes:

```js
if (reqUrl?.endsWith("/content") || /\/[^/]*_content$/.test(reqUrl)) {
```

Both patterns miss the `/$value` suffix, so the gate was never entered for:
- `/odata/v4/.../content/$value`
- `/odata/v4/.../foo_content/$value`

The same blind spot affected `getScanInfo` where the prefix was extracted with `split('/').pop().replace('_content', '')` — for a `/$value` URL this returns `"$value"` instead of the actual field prefix, causing the DB query to look up the wrong column.

## Fix

Introduce two helper functions in `lib/helper.js`:

- `isContentRequest(url)` — matches all four content URL variants (`/content`, `/content/$value`, `/field_content`, `/field_content/$value`) after stripping query string and fragment.
- `extractContentPrefix(url)` — strips the `/$value` suffix before extracting the inline-attachment field prefix; returns `undefined` for the composition-based `/content` pattern.

Both are used in `validateAttachment`, `getScanInfo`, and `readAttachment`, replacing the scattered inline string-matching logic.

## Tests

- `tests/unit/contentUrlHelpers.test.js` — 23 unit tests covering both helpers directly (true/false cases, `/$value`, query strings, fragments, null/undefined).
- `tests/unit/status-gate.test.js` — 3 integration-style tests that call `validateAttachment` with an Infected attachment via `/content`, `/content/$value`, and `/foo_content/$value` URLs and assert `req.reject(403, ...)` is called in all cases.