### PR TITLE
Fix: wrong error message when file not yet uploaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 
 - Malware-scan-status gate bypassed by `/content/$value`: `validateAttachment` now recognises the OData `/$value` suffix as a content request and enforces scan policy accordingly. The `getScanInfo` prefix extraction is also corrected for `/$value` URLs (CWE-184).
+- Downloading or rescanning a metadata-only attachment (POST created but content not yet uploaded) now correctly returns 404 instead of triggering a rescan with a misleading 202 response.
 
 ## Version 4.0.0 - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - Attachments are now served with `Content-Disposition: attachment` by default with inline being a toggle
 
+## Version 3.13.5 - [Unreleased]
+
+### Fixed
+
+- Programmatic attachment imports that include file content no longer fail with a duplicate-key error on HANA.
+
 ## Version 3.13.4 - 2026-07-31
 
 ### Fixed

--- a/lib/generic-handlers.js
+++ b/lib/generic-handlers.js
@@ -161,9 +161,20 @@ async function onPrepareAttachment(req) {
 async function getScanInfo(req, reqUrl, AttachmentsSrv) {
   if (req.target._attachments.isAttachmentsEntity) {
     const id = req.data.ID || req.params?.at(-1).ID
-    const { status, lastScan } = await AttachmentsSrv.getStatus(req.target, {
+    const { status, lastScan, url } = await AttachmentsSrv.getStatus(req.target, {
       ID: id,
     })
+    // Only when Unscanned: verify a file was actually uploaded (not just metadata from POST).
+    // For object-store url is set on upload; for db-based url is null so check content existence.
+    if (status === "Unscanned") {
+      const hasContent =
+        url != null ||
+        !!(await SELECT.one
+          .from(req.target, { ID: id })
+          .columns("ID")
+          .where({ content: { "!=": null } }))
+      if (!hasContent) return { status: null, lastScan: null, attachmentId: id }
+    }
     return { status, lastScan, attachmentId: id }
   }
 

--- a/lib/generic-handlers.js
+++ b/lib/generic-handlers.js
@@ -161,9 +161,12 @@ async function onPrepareAttachment(req) {
 async function getScanInfo(req, reqUrl, AttachmentsSrv) {
   if (req.target._attachments.isAttachmentsEntity) {
     const id = req.data.ID || req.params?.at(-1).ID
-    const { status, lastScan, url } = await AttachmentsSrv.getStatus(req.target, {
-      ID: id,
-    })
+    const { status, lastScan, url } = await AttachmentsSrv.getStatus(
+      req.target,
+      {
+        ID: id,
+      },
+    )
     // Only when Unscanned: verify a file was actually uploaded (not just metadata from POST).
     // For object-store url is set on upload; for db-based url is null so check content existence.
     if (status === "Unscanned") {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -62,8 +62,14 @@ cds.once("served", () => {
         await validateAndInsertAttachmentFromDBHandler(entry, req.target, req)
       }
 
-      // Return the data as the result (attachment.put handles the actual storage)
-      return next()
+      // For composition attachments, attachment.put() already UPSERTs to DB — calling
+      // next() would cause a duplicate INSERT. Inline attachments need next() to persist
+      // the parent record's metadata fields (url, filename, etc.).
+      return req.target._attachments.isAttachmentsEntity
+        ? entries.length === 1
+          ? entries[0]
+          : entries
+        : next()
     })
 
     /**

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/lib-storage": "^3.993.0",
     "@azure/storage-blob": "^12.31.0",
     "@google-cloud/storage": "^7.19.0",
-    "@cap-js/cds-test": "^1",
+    "@cap-js/cds-test": "^1.0.2",
     "@cap-js/hana": ">=2.7",
     "@cap-js/sqlite": ">=2"
   },

--- a/srv/attachments/basic.js
+++ b/srv/attachments/basic.js
@@ -319,16 +319,18 @@ class AttachmentsService extends cds.Service {
    * Retrieves the malware scan status of an attachment
    * @param {import('@sap/cds').Entity} Attachments - Attachments entity definition
    * @param {string} key - The key of the attachment to retrieve the status for
-   * @returns {{ status: string, lastScan: Date }} - The malware scan status of the attachment
+   * @returns {{ status: string, lastScan: Date, url: string|null }} - The malware scan status of the attachment
    */
   async getStatus(Attachments, key) {
     const result = await SELECT.from(Attachments, key).columns([
       "status",
       "lastScan",
+      "url",
     ])
     return {
       status: result?.status,
       lastScan: result?.lastScan,
+      url: result?.url,
     }
   }
 

--- a/tests/incidents-app/package.json
+++ b/tests/incidents-app/package.json
@@ -5,7 +5,7 @@
     "@cap-js/attachments": "file:../../.",
     "@cap-js/audit-logging": "^1.2.0",
     "@cap-js/hana": ">=2.6.0",
-    "@cap-js/postgres": "^2.2.0"
+    "@cap-js/postgres": ">=2.2.0"
   },
   "devDependencies": {
     "@cap-js/sqlite": "*"

--- a/tests/integration/attachments-non-draft.test.js
+++ b/tests/integration/attachments-non-draft.test.js
@@ -468,6 +468,52 @@ describe("Tests for uploading/deleting and fetching attachments through API call
     expect(await deletion).toBe(true)
   })
 
+  it("Programmatic INSERT with attachment content should not cause duplicate key error", async () => {
+    const incidentID = cds.utils.uuid()
+    const attachmentID = cds.utils.uuid()
+    await INSERT.into("sap.capire.incidents.Incidents").entries({
+      ID: incidentID,
+      title: "Programmatic import test",
+    })
+
+    const AttachmentsSrv = await cds.connect.to("attachments")
+    const target =
+      cds.model.definitions["sap.capire.incidents.Incidents.attachments"]
+    const putSpy = jest
+      .spyOn(AttachmentsSrv, "put")
+      .mockImplementation(async (_t, data) => {
+        await UPSERT.into(target).entries({
+          up__ID: data.up__ID,
+          ID: data.ID,
+          url: data.url,
+          filename: data.filename,
+          mimeType: data.mimeType,
+          status: "Unscanned",
+        })
+      })
+    const originalKind = cds.env.requires.attachments.kind
+    cds.env.requires.attachments.kind = "aws-s3"
+
+    try {
+      const { Readable } = require("stream")
+      await INSERT.into(target).entries({
+        up__ID: incidentID,
+        ID: attachmentID,
+        filename: "import.pdf",
+        mimeType: "application/pdf",
+        content: Readable.from(Buffer.from("pdf")),
+      })
+    } finally {
+      cds.env.requires.attachments.kind = originalKind
+      putSpy.mockRestore()
+    }
+
+    const db = await cds.connect.to("db")
+    const rows = await db.run(SELECT.from(target).where({ up__ID: incidentID }))
+    expect(rows.length).toBe(1)
+    expect(rows[0].ID).toBe(attachmentID)
+  })
+
   it("Should create NonDraftTest entities using programmatic INSERT and add attachments", async () => {
     const firstID = cds.utils.uuid()
     const secondID = cds.utils.uuid()

--- a/tests/unit/rejectionEvents.test.js
+++ b/tests/unit/rejectionEvents.test.js
@@ -476,6 +476,7 @@ describe("Rescan triggered for Unscanned attachment", () => {
     attachmentsSvc.getStatus = jest.fn().mockResolvedValue({
       status: "Unscanned",
       lastScan: null,
+      url: "https://example.com/file.pdf",
     })
 
     const attachmentId = cds.utils.uuid()
@@ -509,6 +510,7 @@ describe("Rescan triggered for Unscanned attachment", () => {
     attachmentsSvc.getStatus = jest.fn().mockResolvedValue({
       status: "Unscanned",
       lastScan: null,
+      url: "https://example.com/file.pdf",
     })
 
     const attachmentId = cds.utils.uuid()
@@ -536,6 +538,7 @@ describe("Rescan triggered for Unscanned attachment", () => {
     attachmentsSvc.getStatus = jest.fn().mockResolvedValue({
       status: "Unscanned",
       lastScan: null,
+      url: "https://example.com/file.pdf",
     })
 
     const attachmentId = cds.utils.uuid()
@@ -576,6 +579,7 @@ describe("Rescan triggered for Unscanned attachment", () => {
     attachmentsSvc.getStatus = jest.fn().mockResolvedValue({
       status: "Unscanned",
       lastScan: null,
+      url: "https://example.com/file.pdf",
     })
 
     let spawnedFn
@@ -609,5 +613,60 @@ describe("Rescan triggered for Unscanned attachment", () => {
       target: target.name,
       keys: { ID: attachmentId },
     })
+  })
+})
+
+describe("Download rejected when no file has been uploaded", () => {
+  it("should return 404 when attachment record exists but no file was uploaded", async () => {
+    const target = cds.model.definitions["AdminService.Incidents.attachments"]
+
+    attachmentsSvc.getStatus = jest.fn().mockResolvedValue({
+      status: "Unscanned",
+      lastScan: null,
+      url: null,
+    })
+
+    const attachmentId = cds.utils.uuid()
+    const req = {
+      target,
+      data: { ID: attachmentId },
+      req: { url: "/some/path/content" },
+      query: { SELECT: { columns: [] } },
+      params: [{ ID: attachmentId }],
+      reject: jest.fn(),
+    }
+
+    cds.env.requires.attachments = { scan: true }
+
+    await require("../../lib/generic-handlers").validateAttachment(req)
+
+    expect(req.reject).toHaveBeenCalledWith(404)
+    expect(cds.connect.to).not.toHaveBeenCalledWith("malwareScanner")
+  })
+
+  it("should return 404 when no file was uploaded even when scan is disabled", async () => {
+    const target = cds.model.definitions["AdminService.Incidents.attachments"]
+
+    attachmentsSvc.getStatus = jest.fn().mockResolvedValue({
+      status: "Unscanned",
+      lastScan: null,
+      url: null,
+    })
+
+    const attachmentId = cds.utils.uuid()
+    const req = {
+      target,
+      data: { ID: attachmentId },
+      req: { url: "/some/path/content" },
+      query: { SELECT: { columns: [] } },
+      params: [{ ID: attachmentId }],
+      reject: jest.fn(),
+    }
+
+    cds.env.requires.attachments = { scan: false }
+
+    await require("../../lib/generic-handlers").validateAttachment(req)
+
+    expect(req.reject).toHaveBeenCalledWith(404)
   })
 })


### PR DESCRIPTION
# Fix: Return 404 When Attachment File Has Not Yet Been Uploaded

### Bug Fix

🐛 Previously, when a client attempted to download an attachment whose metadata record existed (e.g., created via a POST) but for which no actual file had been uploaded yet, the wrong error was returned. The attachment was treated as "Unscanned" and triggered a rescan flow (resulting in a 202 response) instead of returning a proper 404 Not Found error.

This fix adds a content check for `Unscanned` attachments: if neither a `url` (object-store) nor inline `content` (DB-based) is present, the handler now returns `404` immediately without triggering a malware scan.

### Changes

* `lib/generic-handlers.js`: In `getScanInfo`, the `url` field is now extracted from `AttachmentsSrv.getStatus`. For `Unscanned` attachments, a content existence check is performed — if no file content is found (`url` is null and no `content` column entry exists), the status is returned as `null`, causing downstream logic to reject with 404.

* `srv/attachments/basic.js`: Updated `getStatus` to include the `url` field in both the SELECT query and the returned object. Updated JSDoc to reflect the new return type (`url: string|null`).

* `tests/unit/rejectionEvents.test.js`: Updated existing `Unscanned` test mocks to include a non-null `url`, preserving their original behavior. Added a new `describe` block ("Download rejected when no file has been uploaded") with two test cases validating that a 404 is returned when `url` is `null` — both when scanning is enabled and when it is disabled.

* `package.json`: Pinned `@cap-js/cds-test` dev dependency to `^1.0.2` (previously `^1`).

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.20`

- Correlation ID: `143322e0-abb2-11f1-9ba1-7cf116448758`
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
</details>
