### PR TITLE
Duplicate key error and 3.13.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Version 3.13.5 - 2026-09-09
+## Version 3.13.5 - 2026-09-11
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 3.13.5 - 2026-09-09
+
+### Fixed
+
+- Programmatic attachment imports that include file content no longer fail with a duplicate-key error on HANA.
+
 ## Version 3.13.4 - 2026-07-31
 
 ### Fixed

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -64,8 +64,14 @@ cds.once("served", () => {
         await validateAndInsertAttachmentFromDBHandler(entry, req.target, req)
       }
 
-      // Return the data as the result (attachment.put handles the actual storage)
-      return next()
+      // For composition attachments, attachment.put() already UPSERTs to DB — calling
+      // next() would cause a duplicate INSERT. Inline attachments need next() to persist
+      // the parent record's metadata fields (url, filename, etc.).
+      return req.target._attachments.isAttachmentsEntity
+        ? entries.length === 1
+          ? entries[0]
+          : entries
+        : next()
     })
 
     /**

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@cap-js/sqlite": ">=2"
   },
   "peerDependencies": {
-    "@sap/cds": ">=8"
+    "@sap/cds": ">=8 <10"
   },
   "cds": {
     "requires": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@google-cloud/storage": "^7.19.0"
   },
   "devDependencies": {
-    "@cap-js/cds-test": "^1",
+    "@cap-js/cds-test": "^1.0.2",
     "@cap-js/hana": "^2.7",
     "@cap-js/sqlite": "^2"
   },

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "devDependencies": {
     "@cap-js/cds-test": "^1",
-    "@cap-js/hana": ">=2.7",
-    "@cap-js/sqlite": ">=2"
+    "@cap-js/hana": "^2.7",
+    "@cap-js/sqlite": "^2"
   },
   "peerDependencies": {
     "@sap/cds": ">=8 <10"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cap-js/attachments",
   "description": "CAP cds-plugin providing image and attachment storing out-of-the-box.",
-  "version": "3.13.4",
+  "version": "3.13.5",
   "repository": "cap-js/attachments",
   "author": "SAP SE (https://www.sap.com)",
   "homepage": "https://cap.cloud.sap/",

--- a/tests/integration/attachments-non-draft.test.js
+++ b/tests/integration/attachments-non-draft.test.js
@@ -497,17 +497,20 @@ describe("Tests for uploading/deleting and fetching attachments through API call
     })
 
     const AttachmentsSrv = await cds.connect.to("attachments")
-    const target = cds.model.definitions["sap.capire.incidents.Incidents.attachments"]
-    const putSpy = jest.spyOn(AttachmentsSrv, "put").mockImplementation(async (_t, data) => {
-      await UPSERT.into(target).entries({
-        up__ID: data.up__ID,
-        ID: data.ID,
-        url: data.url,
-        filename: data.filename,
-        mimeType: data.mimeType,
-        status: "Unscanned",
+    const target =
+      cds.model.definitions["sap.capire.incidents.Incidents.attachments"]
+    const putSpy = jest
+      .spyOn(AttachmentsSrv, "put")
+      .mockImplementation(async (_t, data) => {
+        await UPSERT.into(target).entries({
+          up__ID: data.up__ID,
+          ID: data.ID,
+          url: data.url,
+          filename: data.filename,
+          mimeType: data.mimeType,
+          status: "Unscanned",
+        })
       })
-    })
     const originalKind = cds.env.requires.attachments.kind
     cds.env.requires.attachments.kind = "aws-s3"
 

--- a/tests/integration/attachments-non-draft.test.js
+++ b/tests/integration/attachments-non-draft.test.js
@@ -484,6 +484,53 @@ describe("Tests for uploading/deleting and fetching attachments through API call
     expect(await deletion).toBe(true)
   })
 
+  it("Programmatic INSERT with attachment content should not cause duplicate key error", async () => {
+    // Regression: in 3.13.x the DB handler called next() after attachment.put(), causing
+    // a duplicate INSERT for the same (up__ID, ID) key. Simulate object-store mode by
+    // overriding kind and mocking put() to write metadata to the DB (as the real service
+    // would via UPSERT), then verify the full flow completes without a constraint violation.
+    const incidentID = cds.utils.uuid()
+    const attachmentID = cds.utils.uuid()
+    await INSERT.into("sap.capire.incidents.Incidents").entries({
+      ID: incidentID,
+      title: "Programmatic import test",
+    })
+
+    const AttachmentsSrv = await cds.connect.to("attachments")
+    const target = cds.model.definitions["sap.capire.incidents.Incidents.attachments"]
+    const putSpy = jest.spyOn(AttachmentsSrv, "put").mockImplementation(async (_t, data) => {
+      await UPSERT.into(target).entries({
+        up__ID: data.up__ID,
+        ID: data.ID,
+        url: data.url,
+        filename: data.filename,
+        mimeType: data.mimeType,
+        status: "Unscanned",
+      })
+    })
+    const originalKind = cds.env.requires.attachments.kind
+    cds.env.requires.attachments.kind = "aws-s3"
+
+    try {
+      const { Readable } = require("stream")
+      await INSERT.into(target).entries({
+        up__ID: incidentID,
+        ID: attachmentID,
+        filename: "import.pdf",
+        mimeType: "application/pdf",
+        content: Readable.from(Buffer.from("pdf")),
+      })
+    } finally {
+      cds.env.requires.attachments.kind = originalKind
+      putSpy.mockRestore()
+    }
+
+    const db = await cds.connect.to("db")
+    const rows = await db.run(SELECT.from(target).where({ up__ID: incidentID }))
+    expect(rows.length).toBe(1)
+    expect(rows[0].ID).toBe(attachmentID)
+  })
+
   it("Should create NonDraftTest entities using programmatic INSERT and add attachments", async () => {
     const firstID = cds.utils.uuid()
     const secondID = cds.utils.uuid()


### PR DESCRIPTION
# Fix Duplicate Key Error for Programmatic Attachment Imports

### Bug Fix

🐛 Fixed a duplicate-key error on HANA when programmatically inserting composition attachments with file content. The DB insert interception now avoids calling the default insert flow when `attachment.put()` has already persisted attachment metadata, preventing duplicate records for the same attachment key.

### Changes

* `lib/plugin.js`: Updated DB INSERT handling for attachment entities to return processed attachment entries directly after `attachment.put()` instead of calling `next()`, while preserving `next()` for inline attachments that still need parent metadata persistence.
* `tests/integration/attachments-non-draft.test.js`: Added a regression test covering programmatic INSERT with attachment content in object-store mode, ensuring only one attachment row is persisted without constraint violations.
* `package.json`: Bumped package version from `3.13.4` to `3.13.5` and constrained `@sap/cds` peer dependency to `>=8 <10`.
* `CHANGELOG.md`: Added release notes for version `3.13.5` documenting the duplicate-key fix.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.27`

- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `394b3eb0-ac5b-11f1-8421-ebfe67973e81`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `gpt-5.5`
</details>
